### PR TITLE
Update 3.2-fetching-polymorphic-data.adoc - syntax mistakes

### DIFF
--- a/academy/modules/ROOT/pages/3-reading-data/3.2-fetching-polymorphic-data.adoc
+++ b/academy/modules/ROOT/pages/3-reading-data/3.2-fetching-polymorphic-data.adoc
@@ -246,7 +246,7 @@ match
 entity $entity-type;
 $entity isa! $entity-type;
 fetch {
-  $entity.*;
+  $entity.*
 };
 ----
 


### PR DESCRIPTION
## Goal
Fixing a syntax error in the typedb academy.

## Implementation
Removal of semicolon syntax error in chapter 3.2.

I caught one in the 3.1 doc as well. Should I keep creating new PR's? Perhaps I should go chapter by chapter and then create a PR per complete chapter? Or will these be fixed without my input? I'd be glad to hear your thoughts and what is best practice here. I am learning slowly at this moment, so these changes could be slow to be proposed by me.