### PR TITLE
Update 3.4-fetching-schema-types.adoc - syntax mistakes

### DIFF
--- a/academy/modules/ROOT/pages/3-reading-data/3.4-fetching-schema-types.adoc
+++ b/academy/modules/ROOT/pages/3-reading-data/3.4-fetching-schema-types.adoc
@@ -12,7 +12,7 @@ $book isa book;
 action-execution (executor: $user, action: $action);
 $rel links ($book, $action);
 fetch {
-  "isbn": $book.isbn,
+  "isbn": [$book.isbn],
   "title": $book.title
 };
 ----


### PR DESCRIPTION
## Goal
Resolving syntax error in chapter 3.4 academy to match expected output.

## Implementation
Added square brackets to the first fetch query surrounding $book.isbn.