### PR TITLE
Update config and clustered driver docs, introduce admin tool page

### DIFF
--- a/academy/modules/ROOT/attachments/python-sample-app.py
+++ b/academy/modules/ROOT/attachments/python-sample-app.py
@@ -17,7 +17,7 @@
 
 from enum import Enum
 from typing import Iterator, Optional
-from typedb.driver import TypeDB, TransactionType, Credentials, DriverOptions
+from typedb.driver import TypeDB, TransactionType, Credentials, DriverOptions, DriverTlsConfig
 
 ADDRESS = "localhost:1729"
 DATABASE = "bookstore"
@@ -178,7 +178,7 @@ def search_books(driver) -> None:
 if __name__ == "__main__":
     # Update credentials/options as needed for your deployment
     credentials = Credentials("admin", "password")
-    options = DriverOptions(is_tls_enabled=False, tls_root_ca_path=None)
+    options = DriverOptions(DriverTlsConfig.disabled())
     with TypeDB.driver(ADDRESS, credentials, options) as driver:
         while True:
             print("Available commands:")

--- a/academy/modules/ROOT/pages/6-building-applications/6.2-managing-users-and-databases.adoc
+++ b/academy/modules/ROOT/pages/6-building-applications/6.2-managing-users-and-databases.adoc
@@ -9,12 +9,12 @@ TypeDB Studio manages the connection automatically. With native drivers, instant
 
 [,python]
 ----
-from typedb.driver import TypeDB, Credentials, DriverOptions
+from typedb.driver import TypeDB, Credentials, DriverOptions, DriverTlsConfig
 
 DB = "bookstore"
 address = "localhost:1729"
 credentials = Credentials("admin", "password")
-options = DriverOptions(is_tls_enabled=True, tls_root_ca_path=None)
+options = DriverOptions(DriverTlsConfig.enabled_with_native_root_ca())
 
 with TypeDB.driver(address, credentials, options) as driver:
     # code goes here

--- a/academy/modules/ROOT/pages/6-building-applications/6.3-transactions.adoc
+++ b/academy/modules/ROOT/pages/6-building-applications/6.3-transactions.adoc
@@ -6,12 +6,12 @@ With a connection established to the server via a driver, open transactions dire
 
 [,python]
 ----
-from typedb.driver import TypeDB, TransactionType, Credentials, DriverOptions
+from typedb.driver import TypeDB, TransactionType, Credentials, DriverOptions, DriverTlsConfig
 
 DB = "bookstore"
 address = "localhost:1729"
 credentials = Credentials("admin", "password")
-options = DriverOptions(is_tls_enabled=True, tls_root_ca_path=None)
+options = DriverOptions(DriverTlsConfig.enabled_with_native_root_ca())
 
 with TypeDB.driver(address, credentials, options) as driver:
     # Read transaction

--- a/academy/modules/ROOT/pages/6-building-applications/6.4-executing-queries.adoc
+++ b/academy/modules/ROOT/pages/6-building-applications/6.4-executing-queries.adoc
@@ -14,12 +14,12 @@ Let's run this query within a *read transaction* since we're only reading data.
 
 [,python]
 ----
-from typedb.driver import TypeDB, TransactionType, Credentials, DriverOptions
+from typedb.driver import TypeDB, TransactionType, Credentials, DriverOptions, DriverTlsConfig
 
 DB = "bookstore"
 address = "localhost:1729"
 credentials = Credentials("admin", "password")
-options = DriverOptions(is_tls_enabled=True, tls_root_ca_path=None)
+options = DriverOptions(DriverTlsConfig.enabled_with_native_root_ca())
 
 # Note: options can be omitted if you want to use the default options of True/None
 with TypeDB.driver(address, credentials, options) as driver:

--- a/academy/modules/ROOT/pages/6-building-applications/6.5-processing-results.adoc
+++ b/academy/modules/ROOT/pages/6-building-applications/6.5-processing-results.adoc
@@ -12,12 +12,12 @@ fetch { "title": $book.title, "genre": [$book.genre], "page-count": $book.page-c
 
 [,python]
 ----
-from typedb.driver import TypeDB, Credentials, DriverOptions
+from typedb.driver import TypeDB, Credentials, DriverOptions, DriverTlsConfig
 
 DB = "bookstore"
 address = "localhost:1729"
 credentials = Credentials("admin", "password")
-options = DriverOptions(is_tls_enabled=True, tls_root_ca_path=None)
+options = DriverOptions(DriverTlsConfig.enabled_with_native_root_ca())
 
 with TypeDB.driver(address, credentials, options) as driver:
     with driver.transaction(DB, TransactionType.READ) as tx:

--- a/core-concepts/modules/ROOT/examples/driver/python_driver_setup.py
+++ b/core-concepts/modules/ROOT/examples/driver/python_driver_setup.py
@@ -14,7 +14,7 @@ address = "localhost:1729"
 credentials = Credentials("admin", "password")
 #end::constants_credentials[]
 #tag::constants_options[]
-options = DriverOptions(is_tls_enabled=False, tls_root_ca_path=None)
+options = DriverOptions(DriverTlsConfig.disabled())
 #end::constants_options[]
 #end::constants[]
 #end::import_and_constants[]

--- a/core-concepts/modules/ROOT/examples/driver/python_driver_usage.py
+++ b/core-concepts/modules/ROOT/examples/driver/python_driver_usage.py
@@ -6,7 +6,7 @@ from typedb.driver import *
 DB_NAME = "my_database"
 address = "localhost:1729"
 credentials = Credentials("admin", "password")
-options = DriverOptions(is_tls_enabled=False, tls_root_ca_path=None)
+options = DriverOptions(DriverTlsConfig.disabled())
 #end::import_and_constants[]
 
 #tag::driver_create[]

--- a/guides/modules/ROOT/pages/integrations/graph-viz.adoc
+++ b/guides/modules/ROOT/pages/integrations/graph-viz.adoc
@@ -68,11 +68,11 @@ SIMPLE_QUERY = """
     match $x isa person, has name $n;
 """
 
-from typedb.driver import TypeDB, Credentials, DriverOptions, TypeDB, QueryOptions, TransactionType
+from typedb.driver import TypeDB, Credentials, DriverOptions, DriverTlsConfig, TypeDB, QueryOptions, TransactionType
 
 DB_ADDRESS = "127.0.0.1:1729"
 DB_CREDENTIALS = Credentials("admin", "password")
-DRIVER_OPTIONS = DriverOptions(is_tls_enabled=False)
+DRIVER_OPTIONS = DriverOptions(DriverTlsConfig.disabled())
 QUERY_OPTIONS = QueryOptions()
 QUERY_OPTIONS.include_query_structure = True
 DB_NAME = "typedb-graph-tutorial-py"

--- a/guides/modules/ROOT/pages/integrations/social-network.adoc
+++ b/guides/modules/ROOT/pages/integrations/social-network.adoc
@@ -395,11 +395,15 @@ Excerpt from https://github.com/typedb/typedb-examples/blob/3f992da5eabc273f2b2c
 +
 [source,rust]
 ----
+let tls_config = match config::typedb_tls_enabled() {
+    true => DriverTlsConfig::enabled_with_native_root_ca(),
+    false => DriverTlsConfig::disabled(),
+};
 let driver = Arc::new(
     TypeDBDriver::new(
         config::typedb_address(),
         Credentials::new(config::typedb_username(), config::typedb_password()),
-        DriverOptions::new(config::typedb_tls_enabled(), None).unwrap(),
+        DriverOptions::new(tls_config).unwrap(),
     )
     .await
     .unwrap(),
@@ -413,7 +417,8 @@ Excerpt from https://github.com/typedb/typedb-examples/blob/3f992da5eabc273f2b2c
 +
 [source,python]
 ----
-typedb = TypeDB.driver(TYPEDB_ADDRESS, Credentials(TYPEDB_USERNAME, TYPEDB_PASSWORD), DriverOptions(TYPEDB_TLS_ENABLED, None))
+tls_config = DriverTlsConfig.enabled_with_native_root_ca() if TYPEDB_TLS_ENABLED else DriverTlsConfig.disabled()
+typedb = TypeDB.driver(TYPEDB_ADDRESS, Credentials(TYPEDB_USERNAME, TYPEDB_PASSWORD), DriverOptions(tls_config))
 ----
 
 Java::
@@ -434,7 +439,8 @@ public class TypeDBConfig {
 
     @Bean
     public Driver typeDBDriver() {
-        return TypeDB.driver(TYPEDB_ADDRESS, new Credentials(TYPEDB_USERNAME, TYPEDB_PASSWORD), new DriverOptions(TYPEDB_TLS_ENABLED, null));
+        DriverTlsConfig tlsConfig = TYPEDB_TLS_ENABLED ? DriverTlsConfig.enabledWithNativeRootCA() : DriverTlsConfig.disabled();
+        return TypeDB.driver(TYPEDB_ADDRESS, new Credentials(TYPEDB_USERNAME, TYPEDB_PASSWORD), new DriverOptions(tlsConfig));
     }
 }
 ----

--- a/home/modules/ROOT/pages/install/drivers.adoc
+++ b/home/modules/ROOT/pages/install/drivers.adoc
@@ -160,8 +160,9 @@ import com.typedb.driver.TypeDB;
 import com.typedb.driver.api.Driver;
 import com.typedb.driver.api.Credentials;
 import com.typedb.driver.api.DriverOptions;
+import com.typedb.driver.api.DriverTlsConfig;
 
-try (Driver driver = TypeDB.driver(TypeDB.DEFAULT_ADDRESS, new Credentials("admin", "password"), new DriverOptions(false, null))) {
+try (Driver driver = TypeDB.driver(TypeDB.DEFAULT_ADDRESS, new Credentials("admin", "password"), new DriverOptions(DriverTlsConfig.disabled()))) {
     ...
 }
 ----
@@ -229,7 +230,7 @@ For platform-independent distribution, include all Pinvoke runtimes:
 using TypeDB.Driver;
 using TypeDB.Driver.Api;
 
-using var driver = TypeDB.Driver(TypeDB.DefaultAddress, new Credentials("admin", "password"), new DriverOptions(false, null));
+using var driver = TypeDB.Driver(TypeDB.DefaultAddress, new Credentials("admin", "password"), new DriverOptions(DriverTlsConfig.Disabled()));
 ----
 
 === C# driver resources

--- a/home/modules/ROOT/pages/install/drivers.adoc
+++ b/home/modules/ROOT/pages/install/drivers.adoc
@@ -187,8 +187,9 @@ try (Driver driver = TypeDB.driver(TypeDB.DEFAULT_ADDRESS, new Credentials("admi
 #include "typedb_driver.h"
 
 Credentials* credentials = credentials_new("admin", "password");
-DriverOptions* options = driver_options_new(false, NULL);
-TypeDBDriver* driver = driver_open("127.0.0.1:1729", credentials, options);
+DriverTlsConfig* tls_config = driver_tls_config_new_disabled();
+DriverOptions* options = driver_options_new(tls_config);
+TypeDBDriver* driver = driver_new("127.0.0.1:1729", credentials, options);
 ----
 
 === C driver resources

--- a/maintenance-operation/modules/ROOT/pages/typedb-configuration.adoc
+++ b/maintenance-operation/modules/ROOT/pages/typedb-configuration.adoc
@@ -75,7 +75,7 @@ Each public network endpoint has two addresses:
 
 When the server is reached directly, both can be the same. When the server sits behind a NAT, reverse proxy, or load balancer, the listen address is the local bind (often `0.0.0.0:<port>`) and the advertise address is the externally-reachable host:port that clients should dial.
 
-If `advertise-address` is omitted, the server defaults it to the listen address.
+If `advertise-address` is omitted, the server defaults it to the listen address. Exception: `0.0.0.0` listen address is automatically translated to `127.0.0.1` if no explicit advertise value is set.
 
 [cols=".^3,5"]
 |===

--- a/maintenance-operation/modules/ROOT/pages/typedb-configuration.adoc
+++ b/maintenance-operation/modules/ROOT/pages/typedb-configuration.adoc
@@ -48,7 +48,7 @@ When using the command line to override a specific option, all CLI arguments mus
 * start with the double dash prefix `--`,
 * be separated from their value (if any) either by an equals sign (`--arg=val`) or a whitespace (`--arg val`).
 
-e.g.,  `--server.address=0.0.0.0:1730`
+e.g.,  `--server.listen-address=0.0.0.0:1730`
 
 
 [#_overview]
@@ -58,26 +58,63 @@ e.g.,  `--server.address=0.0.0.0:1730`
 === Server
 
 The `server` section of the configuration contains network and encryption options.
-For example, a server can be booted up on `0.0.0.0:1730` by using this command:
+For example, a server can be booted up to listen on `0.0.0.0:1730` by using this command:
 
 [source,bash]
 ----
-typedb server --server.address=0.0.0.0:1730
+typedb server --server.listen-address=0.0.0.0:1730
 ----
+
+[#_listen_vs_advertise]
+==== Listen vs. advertise addresses
+
+Each public network endpoint has two addresses:
+
+* The *listen* address is what the server binds to locally — the interface and port where it accepts connections.
+* The *advertise* address is what the server reports back to clients (and, in clustered deployments, to peer servers). Clients use the advertise address to connect.
+
+When the server is reached directly, both can be the same. When the server sits behind a NAT, reverse proxy, or load balancer, the listen address is the local bind (often `0.0.0.0:<port>`) and the advertise address is the externally-reachable host:port that clients should dial.
+
+If `advertise-address` is omitted, the server defaults it to the listen address.
+
 [cols=".^3,5"]
 |===
 2+^| Server
-| `server.address`
-| Server host and port. Default value: `0.0.0.0:1729`. +
+| `server.listen-address`
+| Server gRPC listen host and port — the address the server binds to. Default value: `0.0.0.0:1729`. +
+Alias (deprecated): `server.address`. Specifying both `server.listen-address` and `server.address` is rejected.
+
+| `server.advertise-address`
+| Server gRPC advertise host and port — the address shared with clients. Required when the listen and advertise addresses differ (e.g., behind a proxy or NAT). Default value: same as `server.listen-address`.
 
 | `server.http.enabled`
 | Enable/disable HTTP endpoint. Default value: `true`. +
 
-| `server.http.address`
-| HTTP endpoint host and port. Cannot be the same as `server.address`. Default value: `0.0.0.0:8000`. +
+| `server.http.listen-address`
+| HTTP listen host and port — the address the server binds to. Cannot be the same as `server.listen-address`. Default value: `0.0.0.0:8000`. +
+Alias (deprecated): `server.http.address`. Specifying both `server.http.listen-address` and `server.http.address` is rejected.
+
+| `server.http.advertise-address`
+| HTTP advertise URL shared with clients (include the scheme, e.g. `http://127.0.0.1:8000` or `https://typedb.example.com`). Required when the listen and advertise addresses differ. Default value: derived from `server.http.listen-address`.
 
 | `server.authentication.token-expiration-seconds`
 | The amount of seconds generated authentication tokens will remain valid, specified in seconds. Default value: `14400` (4 hours). +
+
+|===
+
+[#_admin]
+==== Admin endpoint
+
+TypeDB exposes a separate admin gRPC endpoint, bound to localhost only, used by the bundled `typedb admin` CLI tool to inspect and manage a running server (see xref:{page-version}@tools::admin.adoc[]).
+
+[cols=".^3,5"]
+|===
+2+^| Server admin
+| `server.admin.enabled`
+| Enable/disable the localhost-only admin endpoint. Default value: `true`. +
+
+| `server.admin.port`
+| Port for the admin endpoint on `127.0.0.1`. Default value: `1728`. +
 
 |===
 

--- a/reference/modules/ROOT/pages/typedb-cluster/console.adoc
+++ b/reference/modules/ROOT/pages/typedb-cluster/console.adoc
@@ -1,14 +1,14 @@
 = Console in clustered TypeDB
 :pageTitle: Console in clustered TypeDB
-:Summary: Cluster-specific features in TypeDB Console: multi-replica connections and replication.
-:keywords: typedb, cluster, driver, replication, failover, consistency level, replicas, primary, secondary
+:Summary: Cluster-specific features in TypeDB Console: multi-replica connections, server routing, and cluster inspection.
+:keywords: typedb, cluster, console, replication, failover, server routing, replicas, primary, secondary
 :test-python: false
 
 TypeDB Console has been updated to connect to TypeDB clusters and automatically operate across multiple server replicas.
 The interface is experimental and may change between releases.
-You'll need an alpha version of TypeDB Console. These are published alongside the mainstream versions, starting with `3.7.0`.
-To access the releases, visit the https://github.com/typedb/typedb-console/releases[TypeDB Console GitHub page] and look for
-the most recent Pre-release item containing the alpha suffix (e.g., `TypeDB Console 3.7.0-alpha-2`).
+You'll need an alpha version of TypeDB Console.
+These are published alongside the mainstream versions, starting with `3.7.0`.
+To access the releases, visit the https://github.com/typedb/typedb-console/releases[TypeDB Console GitHub page] and look for the most recent Pre-release item containing the alpha suffix (e.g., `TypeDB Console 3.7.0-alpha-2`).
 
 == What's different in a clustered deployment?
 
@@ -18,8 +18,7 @@ Cluster-enabled Console adds:
 
 - Flexible connection addresses (single, multiple, or translated).
 - Replica discovery (learning replica addresses from the server).
-- Optional replication disabling for replica-specific debugging.
-- Replica inspection commands (list replicas, show primary).
+- Server inspection commands (list servers, show primary, check version).
 
 == Connecting to a cluster
 
@@ -58,37 +57,19 @@ typedb console --address-translation=public-1.domain:1729=10.0.0.11:1729,public-
 
 This allows Console to translate replica addresses returned by the server into addresses reachable from your environment.
 
-== Disable replication
+== Server inspection commands
 
-A new connection flag `--replication-disabled` is introduced.
+Cluster-enabled Console adds commands to inspect server state.
+All server commands accept an optional address argument to route the request to a specific server (equivalent to `ServerRouting.Direct` in the driver API).
+When no address is given, the request is routed automatically.
 
-If used in a Cluster environment (Cloud or Enterprise), this limits Console to communicate only with the address(es) provided via --address.
+=== server list
 
-This disables:
-
-- redirecting requests to other replicas,
-- automatic address updates based on server-provided replica information.
-
-Use this for administrative/debug workflows when you want to test a specific replica.
-
-[WARNING]
-====
---replication-disabled reduces the success rate of operations in real cluster conditions (for example, when a primary changes).
-Additionally, it switches all operations to use eventual consistency level (instead of the strongest).
-Use it only when you intentionally want to avoid automatic replica discovery and failover.
-====
-
-== Replica inspection commands
-
-Cluster-enabled Console adds basic commands to inspect replica state.
-
-=== replica list
-
-Lists replicas known to the cluster with their statuses (as discovered by Console through the server):
+Lists servers known to the cluster with their statuses:
 
 [source,console]
 ```
->> replica list
+>> server list
  id | address                     | role      | term  | status
 --------------------------------------------------------------------
  1  | ...-0.cluster.typedb.com:80 | secondary | 37    | available
@@ -96,18 +77,42 @@ Lists replicas known to the cluster with their statuses (as discovered by Consol
  3  | ...-2.cluster.typedb.com:80 | primary   | 37    | available
 ```
 
-=== replica primary
-
-Shows the current primary replica:
+To query a specific server directly:
 
 [source,console]
 ```
->> replica primary
+>> server list host1:port1
+```
+
+=== server primary
+
+Shows the current primary server:
+
+[source,console]
+```
+>> server primary
+```
+
+=== server version
+
+Retrieves the TypeDB server version:
+
+[source,console]
+```
+>> server version
+```
+
+To check the version of a specific server:
+
+[source,console]
+```
+>> server version host2:port2
 ```
 
 [NOTE]
 ====
-Replica roles may change over time (for example, during failover or re-election). If you are debugging a specific node, consider using --replication-disabled and connecting directly to that replica.
+Server roles may change over time (for example, during failover or re-election).
+Use `server list` to see up-to-date roles and statuses across all replicas.
 ====
 
 == Next steps

--- a/reference/modules/ROOT/pages/typedb-cluster/drivers.adoc
+++ b/reference/modules/ROOT/pages/typedb-cluster/drivers.adoc
@@ -1,7 +1,7 @@
 = Drivers in clustered TypeDB
 :pageTitle: Drivers in clustered TypeDB
-:Summary: Cluster-specific features in TypeDB drivers: multi-replica connections, failover, and consistency levels.
-:keywords: typedb, cluster, driver, replication, failover, consistency level, replicas, primary, secondary
+:Summary: Cluster-specific features in TypeDB drivers: multi-replica connections, failover, and server routing.
+:keywords: typedb, cluster, driver, replication, failover, server routing, replicas, primary, secondary
 :test-python: false
 
 TypeDB gRPC drivers have been updated to connect to TypeDB clusters and automatically operate across multiple server replicas.
@@ -22,8 +22,8 @@ Cluster-enabled drivers add:
 - Flexible connection addresses (single, multiple, or translated).
 - Replica discovery (learning other replicas from the server).
 - Automatic failover (retrying operations against other replicas).
-- Consistency levels for most operations (strong/eventual/replica-dependent).
-- Cluster inspection.
+- Server routing for inspection operations (automatic or targeted).
+- Cluster inspection (servers, primary server, server version).
 
 == Connecting to a cluster
 
@@ -178,9 +178,9 @@ let driver = TypeDBDriver::new(
 --
 ====
 
-== DriverOptions for replication & failover
+== DriverOptions for cluster connections
 
-Cluster-enabled drivers extend DriverOptions with replication/failover controls.
+Cluster-enabled drivers extend DriverOptions with failover and timeout controls.
 
 === DriverTlsConfig
 
@@ -191,24 +191,19 @@ is required to provide a `DriverTlsConfig` with one of the three modes:
 - enabled TLS, system's native root CA is used: `DriverTlsConfig.enabled_with_native_root_ca()`
 - enabled TLS, custom native root CA is used (provide your own file): `DriverTlsConfig.enabled_with_root_ca("path/to/ca-certificate.pem")`
 
-=== use_replication
-
-If `use_replication = true` (default), the driver may use replicas discovered from the server to execute operations and fail over.
-
-If `use_replication = false`, the driver will behave more like a single-endpoint client and limit itself to the configured address(es), even if the server reports additional replicas.
-This is mostly useful for debugging by cluster's administrators.
-
 === primary_failover_retries
 
-Limits how many times a strongly consistent request will be retried against a new primary if the primary role changes (for example during leader re-election).
+Sets the number of times the driver retries finding and re-routing to the primary server
+on connection failures. This value is used both for polling during leader election (up to
+N+1 attempts with a 2-second sleep between each) and for re-executing a failed request on
+a newly discovered primary. Defaults to 1.
 
-This is relevant for operations that must go to the primary (generally limited to or requested to by the user).
+=== request_timeout_millis
 
-=== replica_discovery_attempts
-
-Limits how many replicas the driver will try when it needs to find a working replica for an operation (for example, an eventually consistent read, or a redirect/failover path).
-
-This can cap the amount of extra work the driver performs when some replicas are unavailable.
+Sets the maximum time (in milliseconds) to wait for a response to a unary RPC request.
+This applies to operations like database creation, user management, and initial
+transaction opening. It does NOT apply to operations within transactions (queries, commits).
+Defaults to 2 hours (7200000 milliseconds).
 
 === Example
 
@@ -221,9 +216,8 @@ Python::
 ----
 driver_options = DriverOptions(
     DriverTlsConfig.enabled_with_native_root_ca(),
-    use_replication=True,
     primary_failover_retries=1,
-    replica_discovery_attempts=5,
+    request_timeout_millis=60_000,
 )
 
 driver = TypeDB.driver(["host1:port1", "host2:port2"], credentials, driver_options)
@@ -236,9 +230,8 @@ Java::
 [source,java]
 ----
 DriverOptions driverOptions = new DriverOptions(DriverTlsConfig.enabledWithNativeRootCA())
-        .useReplication(true)
         .primaryFailoverRetries(1)
-        .replicaDiscoveryAttempts(5);
+        .requestTimeoutMillis(60_000);
 
 Driver driver = TypeDB.driver(
         Set.of("host1:port1", "host2:port2"),
@@ -254,9 +247,8 @@ Rust::
 [source,rust]
 ----
 let driver_options = DriverOptions::new(DriverTlsConfig::enabled_with_native_root_ca())
-    .use_replication(true)
     .primary_failover_retries(1)
-    .replica_discovery_attempts(Some(5));
+    .request_timeout(Duration::from_secs(60));
 
 let driver = TypeDBDriver::new(
     Addresses::try_from_addresses_str(["host1:port1", "host2:port2"]).unwrap(),
@@ -268,44 +260,32 @@ let driver = TypeDBDriver::new(
 --
 ====
 
-== Consistency level
+== Server routing
 
-Cluster-enabled drivers introduce `ConsistencyLevel` to control where an operation executes in a distributed server.
+Cluster-enabled drivers introduce `ServerRouting` to control which server handles an inspection operation.
 
-If you connect to a non-clustered TypeDB edition (e.g. single-node CE), or if a specific operation does not support consistency levels, the driver uses the strongest available behavior by default.
+Most driver operations (database management, user management, transactions) are routed to the most suitable server
+automatically, and failover is handled transparently. `ServerRouting` is available on inspection methods to
+optionally target a specific server. This mechanism will be extended with the evolution of clustered TypeDB.
 
-=== Levels
+=== Variants
 
-==== Strong
-Executes only on the primary replica.
-Provides the strongest guarantees (up-to-date), but may be slower and may require failover if the primary changes.
+==== Auto
 
-==== Eventual
-May execute on secondary replicas.
-Can be faster and more available, but may return stale results (does not guarantee latest writes).
+The driver selects the server automatically (typically the primary in a cluster). This is the default.
 
-Additionally, while the driver work is simplified, the target replica can redirect specific requests to the primary by itself, when required.
-This may lead to a longer execution time, but more consistent results.
+==== Direct
 
-==== Replica dependent
-Targets a specific replica address.
-Useful for debugging, testing, and investigating replica-local behaviour.
+Routes the operation to a specific server by address. Useful for debugging, testing, and investigating replica-local state.
 
-=== Where you can use consistency levels
+=== Where you can use server routing
 
-Cluster-enabled drivers allow a `ConsistencyLevel` parameter on most operations, for example:
+Server routing is available on the following driver methods:
 
-- replica-related read operations (server status)
-- database management (listing, creation, and deletion)
-- user management (listing, creation, and deletion)
-- read transactions/queries
-- database export
+- `servers()` / `primaryServer()` — retrieve cluster server information
+- `serverVersion()` — retrieve the TypeDB version from a specific server
 
-The only operations that do not support non-strongly consistent execution are:
-
-- replica management (alpha-only operations)
-- schema and write transactions/queries
-- database import (currently fully unavailable in clustered TypeDB)
+=== Example
 
 [tabs]
 ====
@@ -314,10 +294,17 @@ Python::
 --
 [source,python]
 ----
-driver.databases.all() # default (strongest possible)
-driver.databases.all(ConsistencyLevel.Strong())
-driver.databases.contains("my_db", ConsistencyLevel.Eventual())
-driver.databases.get("my_db", ConsistencyLevel.ReplicaDependent("host2:port2"))
+# Default routing (automatic)
+driver.servers()
+driver.primary_server()
+driver.server_version()
+
+# Explicit automatic routing
+driver.servers(ServerRouting.Auto())
+
+# Target a specific server
+driver.servers(ServerRouting.Direct("host2:port2"))
+driver.server_version(ServerRouting.Direct("host2:port2"))
 ----
 --
 
@@ -326,10 +313,17 @@ Java::
 --
 [source,java]
 ----
-driver.databases().all(); // default (strongest possible)
-driver.databases().all(new ConsistencyLevel.Strong());
-driver.databases().contains("my_db", new ConsistencyLevel.Eventual());
-driver.databases().get("my_db", new ConsistencyLevel.ReplicaDependent("host2:port2"));
+// Default routing (automatic)
+driver.servers();
+driver.primaryServer();
+driver.serverVersion();
+
+// Explicit automatic routing
+driver.servers(new ServerRouting.Auto());
+
+// Target a specific server
+driver.servers(new ServerRouting.Direct("host2:port2"));
+driver.serverVersion(new ServerRouting.Direct("host2:port2"));
 ----
 --
 
@@ -338,24 +332,59 @@ Rust::
 --
 [source,rust]
 ----
-driver.databases().all().await?; // default (strongest possible)
-driver.databases().all_with_consistency(ConsistencyLevel::Strong).await?;
-driver.databases().contains_with_consistency("my_db", ConsistencyLevel::Eventual).await?;
-driver.databases().get_with_consistency("my_db", ConsistencyLevel::ReplicaDependent { address: "host2:port2".to_owned() }).await?;
+// Default routing (automatic)
+driver.servers().await?;
+driver.primary_server().await?;
+driver.server_version().await?;
+
+// Explicit automatic routing
+driver.servers_with_routing(ServerRouting::Auto).await?;
+
+// Target a specific server
+driver.servers_with_routing(
+    ServerRouting::Direct { address: "host2:port2".parse().unwrap() }
+).await?;
+driver.server_version_with_routing(
+    ServerRouting::Direct { address: "host2:port2".parse().unwrap() }
+).await?;
 ----
 --
 ====
 
 [NOTE]
 ====
-Use Eventual only when your application can tolerate stale reads or variable execution time. If you are unsure, keep the default.
+If you connect to a non-clustered (single-node) TypeDB server, server routing has no effect: all operations go to the single server.
 ====
 
-== Read transaction consistency
+== Inspect your cluster
 
-Write and schema transactions must be opened against a primary replica. For this reason, transaction-level consistency configuration applies to READ transactions only.
+Drivers have access to information about the cluster and its servers.
 
-Cluster-enabled drivers add a read consistency option in TransactionOptions:
+=== Server properties
+
+Each server exposes the following properties:
+
+[cols="1,3"]
+|===
+| Property | Description
+
+| `id`
+| The unique identifier of this server in the cluster.
+
+| `address`
+| The network address this server is available at.
+
+| `role`
+| The replication role of this server: `Primary`, `Candidate`, or `Secondary`. May be absent for non-clustered servers.
+
+| `isPrimary`
+| Whether this server is the current primary (leader) of the cluster.
+
+| `term`
+| The Raft protocol term of this server. Useful for debugging elections and failover. May be absent for non-clustered servers.
+|===
+
+=== Get all servers
 
 [tabs]
 ====
@@ -364,10 +393,9 @@ Python::
 --
 [source,python]
 ----
-options = TransactionOptions(read_consistency_level=ConsistencyLevel.Eventual())
-
-with driver.transaction("my_db", TransactionType.READ, options=options) as tx:
-    answers = tx.query("match $x isa person;").resolve()
+servers = driver.servers()
+for server in servers:
+    print(f"Server {server.id}: {server.address}, role={server.role}, term={server.term}")
 ----
 --
 
@@ -376,11 +404,10 @@ Java::
 --
 [source,java]
 ----
-TransactionOptions options = new TransactionOptions()
-        .readConsistencyLevel(new ConsistencyLevel.Eventual());
-
-try (Transaction tx = driver.transaction("my_db", TransactionType.READ, options)) {
-    var answers = tx.query("match $x isa person;").resolve();
+Set<? extends Server> servers = driver.servers();
+for (Server server : servers) {
+    System.out.printf("Server %d: %s, role=%s, term=%s%n",
+        server.getID(), server.getAddress(), server.getRole(), server.getTerm());
 }
 ----
 --
@@ -390,23 +417,17 @@ Rust::
 --
 [source,rust]
 ----
-let options = TransactionOptions::new()
-    .read_consistency_level(ConsistencyLevel::Eventual);
-
-let tx = driver
-    .transaction_with_options("my_db", TransactionType::Read, options)
-    .await?;
-
-let answer = tx.query("match $x isa person;").await?;
+let servers = driver.servers().await?;
+for server in &servers {
+    if let Some(address) = server.address() {
+        println!("Server at {address}");
+    }
+}
 ----
 --
 ====
 
-This setting affects the transaction opening operation and the replica selection used for that read transaction.
-
-== Inspect your cluster
-
-Drivers have access to the information about the cluster size and its peers. Below is an example of retrieving this information using Python:
+=== Get primary server
 
 [tabs]
 ====
@@ -415,11 +436,9 @@ Python::
 --
 [source,python]
 ----
-# Get all replicas with their statuses
-driver.replicas()
-
-# Get the current primary replica
-driver.primary_replica()
+primary = driver.primary_server()
+if primary is not None:
+    print(f"Primary: {primary.address}")
 ----
 --
 
@@ -428,11 +447,8 @@ Java::
 --
 [source,java]
 ----
-// Get all replicas with their statuses
-Set<? extends ServerReplica> replicas = driver.replicas();
-
-// Get the current primary replica
-Optional<? extends ServerReplica> primary = driver.primaryReplica();
+Optional<? extends Server> primary = driver.primaryServer();
+primary.ifPresent(p -> System.out.println("Primary: " + p.getAddress()));
 ----
 --
 
@@ -441,11 +457,44 @@ Rust::
 --
 [source,rust]
 ----
-// Get all replicas with their statuses
-let replicas = driver.replicas().await?;
+if let Some(primary) = driver.primary_server().await? {
+    println!("Primary: {}", primary.address());
+}
+----
+--
+====
 
-// Get the current primary replica
-let primary = driver.primary_replica().await?;
+=== Get server version
+
+[tabs]
+====
+Python::
++
+--
+[source,python]
+----
+version = driver.server_version()
+print(f"Distribution: {version.distribution}, Version: {version.version}")
+----
+--
+
+Java::
++
+--
+[source,java]
+----
+ServerVersion version = driver.serverVersion();
+System.out.println("Distribution: " + version.getDistribution() + ", Version: " + version.getVersion());
+----
+--
+
+Rust::
++
+--
+[source,rust]
+----
+let version = driver.server_version().await?;
+println!("Distribution: {}, Version: {}", version.distribution(), version.version());
 ----
 --
 ====
@@ -461,45 +510,48 @@ Python::
 ----
 from typedb.driver import (
     TypeDB, Credentials, DriverOptions, DriverTlsConfig,
-    TransactionType, TransactionOptions, ConsistencyLevel
+    TransactionType, ServerRouting
 )
 
 DATABASE_NAME = "clustered-test"
 
 def test_clustered_typedb():
     driver = TypeDB.driver(
-        # Try automatic replicas retrieval by connecting to only a single server!
+        # Try automatic replica discovery by connecting to only a single server!
         # Use a list of addresses to provide multiple addresses instead.
         ADDRESS,
         Credentials(USERNAME, PASSWORD),
-        # New DriverOptions API
-        DriverOptions(DriverTlsConfig.enabled_with_native_root_ca(), use_replication=True),
+        DriverOptions(DriverTlsConfig.enabled_with_native_root_ca()),
     )
 
-    replicas = driver.replicas()
-    addresses = [replica.address for replica in replicas]
-    print(f"Replicas known to the driver: {addresses}")
+    servers = driver.servers()
+    addresses = [server.address for server in servers]
+    print(f"Servers known to the driver: {addresses}")
+
+    primary = driver.primary_server()
+    if primary is not None:
+        print(f"Primary server: {primary.address}")
+
+    version = driver.server_version()
+    print(f"Server version: {version.distribution} {version.version}")
 
     if not driver.databases.contains(DATABASE_NAME):
-        driver.databases.create(DATABASE_NAME, ConsistencyLevel.Strong())
+        driver.databases.create(DATABASE_NAME)
 
     database = driver.databases.get(DATABASE_NAME)
     print(f"Database exists: {database.name}")
 
-    # New TransactionOptions API
-    transaction_options = TransactionOptions(
-        transaction_timeout_millis=100_000,
-        read_consistency_level=ConsistencyLevel.Eventual()
-    )
-
-    # Schema transactions are always strongly consistent
-    with driver.transaction(DATABASE_NAME, TransactionType.SCHEMA, transaction_options) as tx:
+    # Schema transactions are always routed to the primary
+    with driver.transaction(DATABASE_NAME, TransactionType.SCHEMA) as tx:
         tx.query("define entity person;").resolve()
+        tx.commit()
+
+    with driver.transaction(DATABASE_NAME, TransactionType.WRITE) as tx:
         tx.query("insert $p1 isa person; $p2 isa person;").resolve()
         tx.commit()
 
-    # Read transaction will be opened using the consistency level from the options
-    with driver.transaction(DATABASE_NAME, TransactionType.READ, transaction_options) as tx:
+    # Read transactions are routed automatically
+    with driver.transaction(DATABASE_NAME, TransactionType.READ) as tx:
         answer = tx.query("match $p isa person;").resolve()
         rows = list(answer.as_concept_rows())
         print(f"Persons found: {len(rows)}")
@@ -524,13 +576,14 @@ import com.typedb.driver.api.Driver;
 import com.typedb.driver.api.DriverOptions;
 import com.typedb.driver.api.DriverTlsConfig;
 import com.typedb.driver.api.Transaction;
-import com.typedb.driver.api.TransactionOptions;
-import com.typedb.driver.api.ConsistencyLevel;
 import com.typedb.driver.api.QueryAnswer;
+import com.typedb.driver.api.ServerRouting;
 import com.typedb.driver.api.answer.ConceptRow;
-import com.typedb.driver.api.server.ServerReplica;
+import com.typedb.driver.api.server.Server;
+import com.typedb.driver.api.server.ServerVersion;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -539,40 +592,44 @@ public class ClusteredTypeDBExample {
 
     public static void main(String[] args) {
         try (Driver driver = TypeDB.driver(
-                // Try automatic replicas retrieval by connecting to only a single server!
+                // Try automatic replica discovery by connecting to only a single server!
                 // Use Set.of() with multiple addresses to provide multiple addresses instead.
                 ADDRESS,
                 new Credentials(USERNAME, PASSWORD),
-                // New DriverOptions API
-                new DriverOptions(DriverTlsConfig.enabledWithNativeRootCA()).useReplication(true)
+                new DriverOptions(DriverTlsConfig.enabledWithNativeRootCA())
         )) {
-            Set<? extends ServerReplica> replicas = driver.replicas();
-            List<String> addresses = replicas.stream()
-                    .map(ServerReplica::address)
+            Set<? extends Server> servers = driver.servers();
+            List<String> addresses = servers.stream()
+                    .map(Server::getAddress)
                     .collect(Collectors.toList());
-            System.out.println("Replicas known to the driver: " + addresses);
+            System.out.println("Servers known to the driver: " + addresses);
+
+            Optional<? extends Server> primary = driver.primaryServer();
+            primary.ifPresent(p -> System.out.println("Primary server: " + p.getAddress()));
+
+            ServerVersion version = driver.serverVersion();
+            System.out.println("Server version: " + version.getDistribution() + " " + version.getVersion());
 
             if (!driver.databases().contains(DATABASE_NAME)) {
-                driver.databases().create(DATABASE_NAME, new ConsistencyLevel.Strong());
+                driver.databases().create(DATABASE_NAME);
             }
 
             String databaseName = driver.databases().get(DATABASE_NAME).name();
             System.out.println("Database exists: " + databaseName);
 
-            // New TransactionOptions API
-            TransactionOptions transactionOptions = new TransactionOptions()
-                    .transactionTimeoutMillis(100_000)
-                    .readConsistencyLevel(new ConsistencyLevel.Eventual());
-
-            // Schema transactions are always strongly consistent
-            try (Transaction tx = driver.transaction(DATABASE_NAME, Transaction.Type.SCHEMA, transactionOptions)) {
+            // Schema transactions are always routed to the primary
+            try (Transaction tx = driver.transaction(DATABASE_NAME, Transaction.Type.SCHEMA)) {
                 tx.query("define entity person;").resolve();
+                tx.commit();
+            }
+
+            try (Transaction tx = driver.transaction(DATABASE_NAME, Transaction.Type.WRITE)) {
                 tx.query("insert $p1 isa person; $p2 isa person;").resolve();
                 tx.commit();
             }
 
-            // Read transaction will be opened using the consistency level from the options
-            try (Transaction tx = driver.transaction(DATABASE_NAME, Transaction.Type.READ, transactionOptions)) {
+            // Read transactions are routed automatically
+            try (Transaction tx = driver.transaction(DATABASE_NAME, Transaction.Type.READ)) {
                 QueryAnswer answer = tx.query("match $p isa person;").resolve();
                 List<ConceptRow> rows = answer.asConceptRows().stream().collect(Collectors.toList());
                 System.out.println("Persons found: " + rows.size());
@@ -591,62 +648,66 @@ Rust::
 [source,rust]
 ----
 use typedb_driver::{
-    answer::ConceptRow, consistency_level::ConsistencyLevel, Addresses, Credentials, DriverOptions,
-    DriverTlsConfig, TransactionOptions, TransactionType, TypeDBDriver,
+    Addresses, Credentials, DriverOptions, DriverTlsConfig,
+    TransactionType, TypeDBDriver, Server, ServerRouting,
 };
 
 fn test_clustered_typedb() {
     async_std::task::block_on(async {
         let driver = TypeDBDriver::new(
-            // Try automatic replicas retrieval by connecting to only a single server!
+            // Try automatic replica discovery by connecting to only a single server!
             // Use Addresses::try_from_addresses_str() to provide multiple addresses instead.
             Addresses::try_from_address_str(ADDRESS).unwrap(),
             Credentials::new(USERNAME, PASSWORD),
-            // New DriverOptions API
-            DriverOptions::new(DriverTlsConfig::enabled_with_native_root_ca()).use_replication(true),
+            DriverOptions::new(DriverTlsConfig::enabled_with_native_root_ca()),
         )
         .await
         .expect("Error while setting up the driver");
 
-        let replicas = driver.replicas().await.expect("Expected replicas retrieval");
-        let addresses = replicas.iter().map(|replica| replica.address().unwrap()).collect::<Vec<_>>();
-        println!("Replicas known to the driver: {addresses:?}");
+        let servers = driver.servers().await.expect("Expected servers retrieval");
+        let addresses: Vec<_> = servers.iter()
+            .filter_map(|server| server.address().map(|a| a.to_string()))
+            .collect();
+        println!("Servers known to the driver: {addresses:?}");
+
+        if let Some(primary) = driver.primary_server().await.expect("Expected primary check") {
+            println!("Primary server: {}", primary.address());
+        }
+
+        let version = driver.server_version().await.expect("Expected version retrieval");
+        println!("Server version: {} {}", version.distribution(), version.version());
 
         const DATABASE_NAME: &str = "clustered-test";
 
         if !driver.databases().contains(DATABASE_NAME).await.expect("Expected database check") {
-            driver
-                .databases()
-                .create_with_consistency(DATABASE_NAME, ConsistencyLevel::Strong)
-                .await
-                .expect("Expected database creation");
+            driver.databases().create(DATABASE_NAME).await.expect("Expected database creation");
         }
 
         let database = driver.databases().get(DATABASE_NAME).await.expect("Expected database retrieval");
         println!("Database exists: {}", database.name());
 
-        // New TransactionOptions API
-        let transaction_options = TransactionOptions::new()
-            .transaction_timeout(Duration::from_secs(100))
-            .read_consistency_level(ConsistencyLevel::Eventual);
-
-        // Schema transactions are always strongly consistent
+        // Schema transactions are always routed to the primary
         let transaction = driver
-            .transaction_with_options(DATABASE_NAME, TransactionType::Schema, transaction_options.clone())
+            .transaction(DATABASE_NAME, TransactionType::Schema)
             .await
             .expect("Expected schema transaction");
-
         transaction.query("define entity person;").await.expect("Expected schema query");
-        transaction.query("insert $p1 isa person; $p2 isa person;").await.expect("Expected data query");
         transaction.commit().await.expect("Expected schema tx commit");
 
-        // Read transaction will be opened using the consistency level from the options
         let transaction = driver
-            .transaction_with_options(DATABASE_NAME, TransactionType::Read, transaction_options)
+            .transaction(DATABASE_NAME, TransactionType::Write)
             .await
-            .expect("Expected schema transaction");
+            .expect("Expected write transaction");
+        transaction.query("insert $p1 isa person; $p2 isa person;").await.expect("Expected insert query");
+        transaction.commit().await.expect("Expected write tx commit");
+
+        // Read transactions are routed automatically
+        let transaction = driver
+            .transaction(DATABASE_NAME, TransactionType::Read)
+            .await
+            .expect("Expected read transaction");
         let answer = transaction.query("match $p isa person;").await.expect("Expected read query");
-        let rows: Vec<ConceptRow> = answer.into_rows().try_collect().await.unwrap();
+        let rows: Vec<_> = answer.into_rows().try_collect().await.unwrap();
         println!("Persons found: {}", rows.len());
 
         println!("Done!");

--- a/reference/modules/ROOT/pages/typedb-cluster/drivers.adoc
+++ b/reference/modules/ROOT/pages/typedb-cluster/drivers.adoc
@@ -6,12 +6,11 @@
 
 TypeDB gRPC drivers have been updated to connect to TypeDB clusters and automatically operate across multiple server replicas.
 The API is experimental and may change between releases.
-You'll need an alpha version of TypeDB Driver. These are published alongside the mainstream versions, starting with `3.7.0`.
-To access the releases, visit the https://github.com/typedb/typedb-driver/releases[TypeDB Driver GitHub page] and look for
-the most recent Pre-release item containing the alpha suffix (e.g., `TypeDB Driver 3.7.0-alpha-3`).
+You'll need an alpha version of TypeDB Driver.
+These are published alongside the mainstream versions, starting with `3.7.0`.
+To access the releases, visit the https://github.com/typedb/typedb-driver/releases[TypeDB Driver GitHub page] and look for the most recent Pre-release item containing the alpha suffix (e.g., `TypeDB Driver 3.7.0-alpha-3`).
 
-Alternatively, the TypeDB HTTP endpoint and drivers are unchanged and can be used the usual way by explicitly choosing a
-specific replica to send requests to.
+Alternatively, the TypeDB HTTP endpoint and drivers are unchanged and can be used the usual way by explicitly choosing a specific replica to send requests to.
 
 == What's different in a clustered deployment?
 
@@ -69,13 +68,12 @@ let driver = TypeDBDriver::new(
 --
 ====
 
-Even if your cluster has multiple nodes, if the driver successfully connects to this address, it will automatically
-find its peers and establish all the needed connections.
+Even if your cluster has multiple nodes, if the driver successfully connects to this address, it will automatically find its peers and establish all the needed connections.
 
 === Multiple addresses
 
-To increase the chances of connecting to a functioning node, provide multiple addresses. This is helpful in situations
-when one of the replicas is down, and there is no way to retrieve the information about its peers.
+To increase the chances of connecting to a functioning node, provide multiple addresses.
+This is helpful in situations when one of the replicas is down, and there is no way to retrieve the information about its peers.
 
 [tabs]
 ====
@@ -123,8 +121,7 @@ let driver = TypeDBDriver::new(
 
 === Address translation
 
-When replicas advertise private addresses internally (e.g. Docker/Kubernetes/VPC), while the users are outside of the cluster
-network and are provided with a dynamic public addresses unsuitable for server configuration, use address translation.
+When replicas advertise private addresses internally (e.g. Docker/Kubernetes/VPC), while the users are outside of the cluster network and are provided with a dynamic public addresses unsuitable for server configuration, use address translation.
 
 In this mode, you provide a mapping of public -> private addresses, and the driver can translate replica addresses returned by the server into addresses reachable from your environment:
 
@@ -184,8 +181,8 @@ Cluster-enabled drivers extend DriverOptions with failover and timeout controls.
 
 === DriverTlsConfig
 
-TLS configuration has been refactored to avoid ambiguity and protect your data. Now, to construct an options object, it
-is required to provide a `DriverTlsConfig` with one of the three modes:
+TLS configuration has been refactored to avoid ambiguity and protect your data.
+Now, to construct an options object, it is required to provide a `DriverTlsConfig` with one of the three modes:
 
 - disabled TLS (data, including passwords, is sent as plaintext): `DriverTlsConfig.disabled()`
 - enabled TLS, system's native root CA is used: `DriverTlsConfig.enabled_with_native_root_ca()`
@@ -193,16 +190,15 @@ is required to provide a `DriverTlsConfig` with one of the three modes:
 
 === primary_failover_retries
 
-Sets the number of times the driver retries finding and re-routing to the primary server
-on connection failures. This value is used both for polling during leader election (up to
-N+1 attempts with a 2-second sleep between each) and for re-executing a failed request on
-a newly discovered primary. Defaults to 1.
+Sets the number of times the driver retries finding and re-routing to the primary server on connection failures.
+This value is used both for polling during leader election (up to N+1 attempts with a 2-second sleep between each) and for re-executing a failed request on a newly discovered primary.
+Defaults to 1.
 
 === request_timeout_millis
 
 Sets the maximum time (in milliseconds) to wait for a response to a unary RPC request.
-This applies to operations like database creation, user management, and initial
-transaction opening. It does NOT apply to operations within transactions (queries, commits).
+This applies to operations like database creation, user management, and initial transaction opening.
+It does NOT apply to operations within transactions (queries, commits).
 Defaults to 2 hours (7200000 milliseconds).
 
 === Example
@@ -264,19 +260,20 @@ let driver = TypeDBDriver::new(
 
 Cluster-enabled drivers introduce `ServerRouting` to control which server handles an inspection operation.
 
-Most driver operations (database management, user management, transactions) are routed to the most suitable server
-automatically, and failover is handled transparently. `ServerRouting` is available on inspection methods to
-optionally target a specific server. This mechanism will be extended with the evolution of clustered TypeDB.
+Most driver operations (database management, user management, transactions) are routed to the most suitable server automatically, and failover is handled transparently. `ServerRouting` is available on inspection methods to optionally target a specific server.
+This mechanism will be extended with the evolution of clustered TypeDB.
 
 === Variants
 
 ==== Auto
 
-The driver selects the server automatically (typically the primary in a cluster). This is the default.
+The driver selects the server automatically (typically the primary in a cluster).
+This is the default.
 
 ==== Direct
 
-Routes the operation to a specific server by address. Useful for debugging, testing, and investigating replica-local state.
+Routes the operation to a specific server by address.
+Useful for debugging, testing, and investigating replica-local state.
 
 === Where you can use server routing
 

--- a/test/code/runners/base_runner.py
+++ b/test/code/runners/base_runner.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional
-from typedb.driver import TypeDB, TransactionType, Credentials, DriverOptions
+from typedb.driver import TypeDB, TransactionType, Credentials, DriverOptions, DriverTlsConfig
 
 TEST_CONFIG_KEY_RESET = "reset"
 TEST_CONFIG_KEY_RESET_AFTER = "reset-after"
@@ -21,7 +21,7 @@ class BaseRunner(ABC):
         self.failure_count = 0
 
     def reset_local_databases(self):
-        driver = TypeDB.driver(address=self.uri, credentials=Credentials(self.username,self.password), driver_options=DriverOptions(False, None))
+        driver = TypeDB.driver(address=self.uri, credentials=Credentials(self.username,self.password), driver_options=DriverOptions(DriverTlsConfig.disabled()))
         for database in driver.databases.all():
             database.delete()
         for user in driver.users.all():

--- a/test/code/runners/typeql_runner.py
+++ b/test/code/runners/typeql_runner.py
@@ -1,4 +1,4 @@
-from typedb.driver import TypeDB, Driver, TransactionType, Credentials, DriverOptions
+from typedb.driver import TypeDB, Driver, TransactionType, Credentials, DriverOptions, DriverTlsConfig
 from test.code.runners.base_runner import BaseRunner, TEST_CONFIG_KEY_RESET
 from enum import Enum
 from typing import List, Dict, Tuple, Union
@@ -52,7 +52,7 @@ class TypeqlRunner(BaseRunner):
         self.driver = self.create_driver()
 
     def create_driver(self) -> Driver:
-        return TypeDB.driver(self.uri, Credentials(self.username, self.password), DriverOptions(False, None))
+        return TypeDB.driver(self.uri, Credentials(self.username, self.password), DriverOptions(DriverTlsConfig.disabled()))
 
     def delete_db(self):
         if self.driver.databases.contains(self.db):

--- a/tools/modules/ROOT/pages/admin.adoc
+++ b/tools/modules/ROOT/pages/admin.adoc
@@ -1,0 +1,97 @@
+= TypeDB Admin Tool
+:keywords: typedb, admin, cli, server, status, version
+:pageTitle: TypeDB Admin Tool
+:summary: Localhost CLI for inspecting and managing a running TypeDB server.
+
+`typedb admin` is a CLI tool bundled with every TypeDB distribution.
+It connects to the server's localhost-only admin endpoint to inspect server status and run administrative commands.
+
+Because the admin endpoint binds to `127.0.0.1` only, the admin tool must run on the same host as the server.
+
+== Connect
+
+By default the admin tool connects to `127.0.0.1:1728` — the default address of the server's admin endpoint.
+
+[source,bash]
+----
+typedb admin
+----
+
+To target a non-default admin port (e.g., when `server.admin.port` is overridden in the server config):
+
+[source,bash]
+----
+typedb admin --address 127.0.0.1:1738
+----
+
+== Modes
+
+The admin tool supports three modes.
+
+=== Interactive (REPL)
+
+Run with no `--command` or `--script` to enter an interactive REPL.
+
+[source,bash]
+----
+typedb admin
+----
+
+The REPL prints the connected server's distribution and version, then accepts commands one at a time. Use `help` to list available commands, and `exit` to quit.
+
+=== One-shot commands
+
+Pass one or more `--command` (`-c`) flags to execute commands and exit. Useful in scripts and CI checks.
+
+[source,bash]
+----
+typedb admin --command "server status"
+typedb admin -c "server version" -c "server status"
+----
+
+The exit code is non-zero if any command fails.
+
+=== Script
+
+Execute a file containing one command per line and exit.
+
+[source,bash]
+----
+typedb admin --script ./admin-checks.txt
+----
+
+`--command` and `--script` cannot be combined.
+
+== Commands
+
+[cols=".^3,5"]
+|===
+2+^| Built-in commands
+| `server version`
+| Print the running server's distribution name and version.
+
+| `server status`
+| Print every endpoint the server is serving on (gRPC, HTTP, admin) along with each one's listen and advertise addresses (when they differ).
+
+| `help`
+| List all available commands.
+
+| `exit`
+| Leave the REPL.
+|===
+
+== Example
+
+[source,bash]
+----
+$ typedb admin --command "server status"
+Status: running
+Serving:
+  gRPC:  0.0.0.0:1729 (connect via 127.0.0.1:1729)
+  HTTP:  0.0.0.0:8000 (connect via http://127.0.0.1:8000)
+  Admin: 127.0.0.1:1728
+----
+
+== Disabling the admin endpoint
+
+The admin endpoint is enabled by default. To disable it, set `server.admin.enabled: false` in the server config — see xref:{page-version}@maintenance-operation::typedb-configuration.adoc#_admin[Server configuration / Admin endpoint]. With the endpoint disabled, `typedb admin` will fail to connect.

--- a/tools/modules/ROOT/pages/index.adoc
+++ b/tools/modules/ROOT/pages/index.adoc
@@ -17,6 +17,12 @@ TypeDB Studio - the visual web client for TypeDB.
 TypeDB Console - the CLI client for TypeDB.
 ****
 
+.xref:{page-version}@tools::admin.adoc[]
+[.clickable]
+****
+TypeDB Admin Tool - localhost CLI for inspecting and managing a running TypeDB server.
+****
+
 .xref:{page-version}@tools::ide-plugins.adoc[]
 [.clickable]
 ****

--- a/tools/modules/ROOT/partials/nav.adoc
+++ b/tools/modules/ROOT/partials/nav.adoc
@@ -4,6 +4,8 @@
 
 * xref:{page-version}@tools::console.adoc[]
 
+* xref:{page-version}@tools::admin.adoc[]
+
 * xref:{page-version}@tools::ide-plugins.adoc[]
 
 * xref:{page-version}@tools::typedb-cloud-api.adoc[]


### PR DESCRIPTION
## Goal
Introduce changes to the clustered-specific docs pages for TypeDB clients representing the latest release of the clustered tools after post-alpha stage updates.

Adjust the configuration documentation to the latest changes to TypeDB, introducing the notion of `listen-address`, `advertise-address`, and the admin tool configuration.

Add a new page dedicated to the admin tool.

Update the driver construction examples to reflect the new syntax using `DriverTlsConfig`.

## Implementation

Config:
- Added info about `listen-address`
- Added info about `advertise-address`
- Added info about the admin tool configuration (`enabled` and `port`)

Added a new page for the admin tool docs.

Drivers:
- Remove `ConsistencyLevel`
- Remove deprecated options and flags
- Add `ServerRouting` (to both Driver and Console pages)
- Change the information about available routable methods
- Change Console CLI terminology
- Update all the pages with the construction of `DriverOptions`
- Misc