### PR TITLE
Revive "Manual install" sections for CE and Studio

### DIFF
--- a/home/modules/ROOT/pages/install/ce.adoc
+++ b/home/modules/ROOT/pages/install/ce.adoc
@@ -4,10 +4,21 @@
 You can run TypeDB Community Edition (CE) locally or inside a Docker container.
 TypeDB CE is free & open source!
 
-[#_manual]
-== Install
+[#_installer_script]
+== Installer script
 
-include::{page-version}@home::partial$ce_install.adoc[tag=install]
+include::{page-version}@home::partial$ce_install.adoc[tag=install-script]
+
+=== Run
+
+include::{page-version}@home::partial$ce_distributions.adoc[tag=core-run]
+
+include::{page-version}@home::partial$ce_distributions.adoc[tag=core-stop]
+
+[#_package_manager]
+== Package manager
+
+include::{page-version}@home::partial$ce_install.adoc[tag=package-manager]
 
 === Run
 
@@ -31,6 +42,17 @@ include::{page-version}@home::partial$ce_docker.adoc[tags=run-info]
 include::{page-version}@home::partial$ce_docker.adoc[tag=start]
 
 include::{page-version}@home::partial$ce_docker.adoc[tag=stop]
+
+[#_manual_install]
+== Manual install
+
+include::{page-version}@home::partial$ce_distributions.adoc[tag=core-manual-install]
+
+=== Run
+
+include::{page-version}@home::partial$ce_distributions.adoc[tag=core-run]
+
+include::{page-version}@home::partial$ce_distributions.adoc[tag=core-stop]
 
 == Next steps
 

--- a/home/modules/ROOT/pages/install/console-cli.adoc
+++ b/home/modules/ROOT/pages/install/console-cli.adoc
@@ -9,6 +9,35 @@ The TypeDB Console CLI is packaged and distributed together with the TypeDB CE d
 
 include::{page-version}@home::partial$console_install.adoc[tag=install]
 
+== Run
+
+TypeDB Console can connect to TypeDB CE, TypeDB Cloud instances, or TypeDB Enterprise deployments.
+Running TypeDB Console initiates a network connection to a TypeDB server.
+
+.Connect to TypeDB
+[source,console]
+----
+typedb console --address=<server-address> --username=<username>
+----
+
+You will be prompted for a password.
+
+Use `--tls-disabled` to connect to a server without encryption.
+
+[NOTE]
+=====
+The default username and password are `admin` and `password`.
+After connecting for the first time, you will be able to change the password.
+=====
+
+As a result, you get a welcome message from TypeDB Console followed by a command line prompt.
+
+----
+Welcome to TypeDB Console.
+
+>>
+----
+
 == Getting Started
 
 After installation, you can connect to TypeDB servers. For detailed connection instructions and usage guides, see:

--- a/home/modules/ROOT/pages/install/studio.adoc
+++ b/home/modules/ROOT/pages/install/studio.adoc
@@ -8,36 +8,38 @@ all within a unified environment.
 TypeDB Studio is available both as a web app and as a desktop application. All features of TypeDB Studio
 are available on both web and desktop. Be aware that the web app may not be able to connect to non-HTTPS endpoints (e.g. localhost, 127.0.0.1) on certain browsers; at the time of writing, Chrome works, but Safari does not.
 
-[cols-2]
---
-.https://studio.typedb.com[Visit studio.typedb.com]
-[.clickable]
-****
-Launch TypeDB Studio in your web browser.
-****
+== Launch TypeDB Studio (Web version)
 
-.https://cloudsmith.io/~typedb/repos/public-release/packages/?q=name:%5Etypedb-studio[Install TypeDB Studio Desktop,window=_blank]
-[.clickable]
-****
-Download TypeDB Studio for desktop.
-****
+* https://studio.typedb.com[https://studio.typedb.com] - Launch TypeDB Studio in your web browser.
 
-.link:https://github.com/typedb/typedb-studio/[GitHub,window=_blank]
-[.clickable]
-****
-Browse the source code of TypeDB Studio.
-****
---
+== Install TypeDB Studio Desktop
 
-== TypeDB Studio User Manual
+Download the latest distribution of TypeDB Studio from the table below.
 
-For connection instructions and usage guides, see:
+[cols="^.^1,^.^1,^.^1,^.^1",caption="",options="header"]
+|===
+|Release notes |macOS |Linux |Windows
 
-[cols-2]
---
-.xref:{page-version}@tools::studio.adoc[TypeDB Studio User Manual]
-[.clickable]
-****
-How to use TypeDB Studio.
-****
---
+|
+https://github.com/typedb/typedb-studio/releases/latest[latest]
+
+|
+https://repo.typedb.com/public/public-release/raw/names/typedb-studio-mac-x86_64/versions/latest/download[x86_64]
+/ https://repo.typedb.com/public/public-release/raw/names/typedb-studio-mac-arm64/versions/latest/download[arm64]
+
+|
+https://repo.typedb.com/public/public-release/raw/names/typedb-studio-linux-x86_64/versions/latest/download[x86_64]
+/ https://repo.typedb.com/public/public-release/raw/names/typedb-studio-linux-arm64/versions/latest/download[arm64]
+
+|
+https://repo.typedb.com/public/public-release/raw/names/typedb-studio-windows-x86_64/versions/latest/download[x86_64]
+|===
+
+For all versions,
+see the link:https://cloudsmith.io/~typedb/repos/public-release/packages/?q=typedb-studio&sort=-version[Packages] page.
+
+== Getting Started
+
+After launching TypeDB Studio, you can connect to TypeDB servers. For detailed connection instructions and usage guides, see:
+
+* xref:{page-version}@tools::studio.adoc[] - Complete Studio documentation and connection guide

--- a/home/modules/ROOT/partials/ce_distributions.adoc
+++ b/home/modules/ROOT/partials/ce_distributions.adoc
@@ -11,7 +11,73 @@ include::{page-version}@home:resources:partial$typedb-all-latest-links.adoc[]
 For all versions,
 see the link:https://cloudsmith.io/~typedb/repos/public-release/packages/?q=typedb-all&sort=-version[Packages] page.
 
-Unzip the downloaded file in a location that is easily accessible from your terminal. The unzipped folder contains the `typedb` binary.
+[tabs]
+====
+macOS::
++
+--
+. Extract the archive with TypeDB into a new directory:
++
+[source,console]
+----
+sudo mkdir /opt/typedb
+unzip ~/Downloads/<filename>.zip -d /opt/typedb
+----
++
+Where `<filename>` is the name of the archive.
+
+. Add a symlink to the TypeDB executable in the `/usr/local/bin` directory:
++
+[source,console]
+----
+ln -s /opt/typedb/<filename>/typedb /usr/local/bin/typedb
+----
+--
+
+Linux::
++
+--
+. Extract the archive with TypeDB into a new directory:
++
+[source,console]
+----
+mkdir /opt/typedb
+tar -xzf ~/Downloads/<filename>.tar.gz -C /opt/typedb
+----
++
+Where `<filename>` is the name of the archive.
+
+. Add a symlink to the TypeDB executable in the `/usr/local/bin` directory:
++
+[source,console]
+----
+ln -s /opt/typedb/<filename>/typedb /usr/local/bin/typedb
+----
+--
+
+Windows::
++
+--
+. Extract the archive with TypeDB into a new directory:
++
+[source,console]
+----
+mkdir "C:\Program Files\TypeDB"
+tar xvf "C:\Users\username\Downloads\<filename>.zip" -C "C:\Program Files\TypeDB"
+----
++
+Where `<filename>` is the name of the archive.
+
+. Update the `PATH` environment variable:
++
+[source,console]
+----
+setx /M PATH "%path%;C:\Program Files\TypeDB\<filename>"
+----
++
+Restart the terminal window for the changes to environment variables to take effect.
+--
+====
 // end::core-manual-install[]
 
 // tag::core-run[]

--- a/home/modules/ROOT/partials/ce_install.adoc
+++ b/home/modules/ROOT/partials/ce_install.adoc
@@ -1,4 +1,4 @@
-// tag::install[]
+// tag::install-script[]
 [tabs]
 ====
 macOS::
@@ -6,17 +6,49 @@ macOS::
 --
 **Install using the install script**
 
-Use the TypeDB https://typedb.com/install.sh[install script]. This script
-securely downloads the latest version of TypeDB and installs it to `$HOME/.typedb`.
+This script securely downloads the latest version of TypeDB and installs it to `$HOME/.typedb`.
 
 [source,shell]
 ----
 curl -sSL https://typedb.com/install.sh | sh && export PATH="$HOME/.typedb:$PATH"
 ----
+--
 
-**Or install using Homebrew**
+Linux::
++
+--
+**Install using the install script**
 
-Install the TypeDB Homebrew package using the command:
+This script securely downloads the latest version of TypeDB and installs it to `$HOME/.typedb`.
+
+[source,shell]
+----
+curl -sSL https://typedb.com/install.sh | sh && export PATH="$HOME/.typedb:$PATH"
+----
+--
+
+Windows::
++
+--
+**Install using the install script**
+
+This script securely downloads the latest version of TypeDB and installs it to `%LOCALAPPDATA%\TypeDB`.
+
+[source,powershell]
+----
+iwr https://typedb.com/install.ps1 -useb | iex
+----
+--
+====
+// end::install-script[]
+
+// tag::package-manager[]
+[tabs]
+====
+macOS::
++
+--
+**Install using Homebrew**
 
 [source,shell]
 ----
@@ -27,19 +59,7 @@ brew install typedb/tap/typedb
 Linux::
 +
 --
-**Install using the install script**
-
-Use the TypeDB https://typedb.com/install.sh[install script]. This script
-securely downloads the latest version of TypeDB and installs it to `$HOME/.typedb`.
-
-[source,shell]
-----
-curl -sSL https://typedb.com/install.sh | sh && export PATH="$HOME/.typedb:$PATH"
-----
-
-**Or install using apt**
-
-Install the TypeDB apt package using the following commands.
+**Install using apt**
 
 [source,shell]
 ----
@@ -55,16 +75,7 @@ sudo apt install typedb
 Windows::
 +
 --
-**Install using the install script**
-
-Use the TypeDB https://typedb.com/install.ps1[install script]. This script
-securely downloads the latest version of TypeDB and installs it to `%LOCALAPPDATA%\TypeDB`.
-
-[source,powershell]
-----
-iwr https://typedb.com/install.ps1 -useb | iex
-----
-
+Package manager installation is not yet available for Windows. Use the <<_installer_script,easy installer script>> or perform a <<_manual_install,manual installation>> instead.
 --
 ====
-// end::install[] 
+// end::package-manager[]

--- a/home/modules/ROOT/partials/console_install.adoc
+++ b/home/modules/ROOT/partials/console_install.adoc
@@ -69,4 +69,4 @@ iwr https://typedb.com/install.ps1 -useb | iex
 
 --
 ====
-// end::install[] 
+// end::install[]

--- a/tools/modules/ROOT/partials/console_connect.adoc
+++ b/tools/modules/ROOT/partials/console_connect.adoc
@@ -25,4 +25,4 @@ Welcome to TypeDB Console.
 
 >>
 ----
-// end::connect[] 
+// end::connect[]


### PR DESCRIPTION
## Goal

For completeness, we add to the TypeDB CE and TypeDB Studio Install pages, now exposing direct download links for the latest TypeDB CE and TypeDB Studio versions depending on your operating platform.

Also, TypeDB CE now splits "Installer script" and "Package manager" as two separate sections rather than rolling them into one.

## Implementation

- New section in TypeDB CE Install page: direct download links for TypeDB CE
- Split section in TypeDB CE Install page: "Installer script" and "Package manager" are now separate
- TypeDB Studio install page: split into "Web" and "Desktop" sections where the Desktop section resembles the direct download links section from the CE page

The manual install sections use magic URLs provided by Cloudsmith to download from it without having to go through its Web UI. The URLs have a fragment called `latest` so they won't need constant updating.

They also contain links directly to Cloudsmith to offer older distributions.

<img width="1540" height="1081" alt="image" src="https://github.com/user-attachments/assets/3844c4fa-b10d-4d55-8ea5-5d9b1f0a01f0" />

<img width="1498" height="1052" alt="image" src="https://github.com/user-attachments/assets/93f47e4c-2e2d-4430-a9e2-6ca3a055e40d" />
