### PR TITLE
Fix TypeQL fetch syntax errors in docs

### DIFF
--- a/academy/modules/ROOT/pages/3-reading-data/3.1-fetching-simple-data.adoc
+++ b/academy/modules/ROOT/pages/3-reading-data/3.1-fetching-simple-data.adoc
@@ -158,9 +158,9 @@ Write a query to instead retrieve the `isbn-13`, `price`, and `stock` attributes
 match
 $book isa paperback;
 fetch {
-  "isbn-13": $book.isbn-13
+  "isbn-13": $book.isbn-13,
   "price": $book.price,
-  "stock": $book.stock;
+  "stock": $book.stock
 };
 ----
 

--- a/academy/modules/ROOT/pages/3-reading-data/3.2-fetching-polymorphic-data.adoc
+++ b/academy/modules/ROOT/pages/3-reading-data/3.2-fetching-polymorphic-data.adoc
@@ -121,7 +121,7 @@ Write a query to retrieve _all_ ISBNs of _all_ books in the database.
 match
 $book isa book;
 fetch {
-  "isbn": $book.isbn
+  "isbn": [$book.isbn]
 };
 ----
 

--- a/academy/modules/ROOT/pages/4-writing-data/4.3-deleting-data.adoc
+++ b/academy/modules/ROOT/pages/4-writing-data/4.3-deleting-data.adoc
@@ -54,7 +54,7 @@ To get the correct ISBN, you can use the following query.
 match
 $calvin-hobbes isa book, has title "The Complete Calvin and Hobbes";
 fetch {
-  "isbn": $calvin-hobbes.isbn,
+  "isbn": [$calvin-hobbes.isbn],
 };
 ----
 =====
@@ -151,7 +151,7 @@ To get the correct ISBN, you can use the following query.
 match
 $pet-sematary isa book, has title "Pet Sematary";
 fetch {
-  "isbn": $pet-sematary.isbn;
+  "isbn": [$pet-sematary.isbn]
 };
 ----
 =====

--- a/core-concepts/modules/ROOT/pages/drivers/best-practices.adoc
+++ b/core-concepts/modules/ROOT/pages/drivers/best-practices.adoc
@@ -144,7 +144,7 @@ class TypeDBClient:
     
     def get_users(self):
         with self.driver.transaction("users", TransactionType.READ) as tx:
-            return list(tx.query("match $u isa user; fetch {{ $u.*; }};").resolve().as_concept_documents())
+            return list(tx.query("match $u isa user; fetch {{ $u.* }};").resolve().as_concept_documents())
     
     def get_products(self):
         with self.driver.transaction("products", TransactionType.READ) as tx:

--- a/core-concepts/modules/ROOT/pages/typedb/crud.adoc
+++ b/core-concepts/modules/ROOT/pages/typedb/crud.adoc
@@ -191,15 +191,15 @@ fetch {
 The `fetch` stage above will return a document for each person in the database, containing the person's name and a list of names of their
 friends.
 
-[,typeql]
+[,json]
 ----
 {
-  "name": "Alice"
+  "name": "Alice",
   "friends": [
     "Bob",
     "Carol",
     "Dean"
-  ],
+  ]
 }
 {
   "name": "Eve",


### PR DESCRIPTION
## Goal

Following the patterns identified in #1033 (trailing semicolon in fetch blocks) and #1034 (missing list brackets around multi-valued attributes), this fixes additional occurrences.

## Implementation

- 3.1-fetching-simple-data.adoc: missing comma after "isbn-13" entry and trailing ";" on the "stock" entry of the same fetch block.
- 3.2-fetching-polymorphic-data.adoc: bare "$book.isbn" wrapped in list brackets ("isbn" has cardinality @card(0..2) per this same page's earlier example).
- 4.3-deleting-data.adoc: two "$book.isbn" hint queries wrapped in list brackets; the second also had a trailing semicolon.
- drivers/best-practices.adoc: trailing ";" inside fetch in the Python-f-string example (compare get_products on the next line).
- typedb/crud.adoc: JSON output block was mislabeled as [,typeql], and was missing a comma after "name": "Alice".

