### PR TITLE
Complete driver examples migration to 3.11

### DIFF
--- a/academy/modules/ROOT/pages/6-building-applications/6.2-managing-users-and-databases.adoc
+++ b/academy/modules/ROOT/pages/6-building-applications/6.2-managing-users-and-databases.adoc
@@ -131,5 +131,5 @@ While Admins can manipuluate users, regular and admin users can retrieve the use
 with TypeDB.driver(address, credentials, options) as driver:
     # Retrieves a user object corresponding to the current user,
     # according to the credentials provided to the driver object.
-    current_user: User = driver.users.get_current_user()
+    current_user: User = driver.users.get_current()
 ----

--- a/core-concepts/modules/ROOT/pages/drivers/authentication.adoc
+++ b/core-concepts/modules/ROOT/pages/drivers/authentication.adoc
@@ -110,7 +110,7 @@ with TypeDB.driver(address, credentials, options) as driver:
 
 user_credentials = Credentials("demo_user", "test_password")
 with TypeDB.driver(address, user_credentials, options) as driver:
-    driver.users.get_current_user().update_password("password")
+    driver.users.get_current().update_password("password")
     print("Demo user updated password successfully")
 
 with TypeDB.driver(address, credentials, options) as driver:

--- a/dependencies/typedb/artifacts.bzl
+++ b/dependencies/typedb/artifacts.bzl
@@ -25,5 +25,5 @@ def typedb_artifact():
         artifact_name = "typedb-all-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        tag = "3.10.4",
+        tag = "3.11.0-rc1",
     )

--- a/home/modules/ROOT/pages/install/drivers.adoc
+++ b/home/modules/ROOT/pages/install/drivers.adoc
@@ -60,7 +60,7 @@ pip install typedb-driver
 ----
 from typedb.driver import *
 
-driver = TypeDB.driver(address=TypeDB.DEFAULT_ADDRESS, ...)
+driver = TypeDB.driver(TypeDB.DEFAULT_ADDRESS, Credentials("admin", "password"), DriverOptions(DriverTlsConfig.disabled()))
 ----
 
 === Python driver resources
@@ -116,9 +116,13 @@ cargo add typedb-driver
 +
 [source,rust]
 ----
-use typedb_driver::TypeDBDriver;
+use typedb_driver::{Addresses, Credentials, DriverOptions, DriverTlsConfig, TypeDBDriver};
 
-let driver = TypeDBDriver::new_core(TypeDBDriver::DEFAULT_ADDRESS).await.unwrap();
+let driver = TypeDBDriver::new(
+    Addresses::try_from_address_str(TypeDBDriver::DEFAULT_ADDRESS).unwrap(),
+    Credentials::new("admin", "password"),
+    DriverOptions::new(DriverTlsConfig::disabled()),
+).await.unwrap();
 ----
 
 === Rust driver resources
@@ -189,7 +193,7 @@ try (Driver driver = TypeDB.driver(TypeDB.DEFAULT_ADDRESS, new Credentials("admi
 Credentials* credentials = credentials_new("admin", "password");
 DriverTlsConfig* tls_config = driver_tls_config_new_disabled();
 DriverOptions* options = driver_options_new(tls_config);
-TypeDBDriver* driver = driver_new("127.0.0.1:1729", credentials, options);
+TypeDBDriver* driver = driver_new("127.0.0.1:1729", credentials, options, NULL);
 ----
 
 === C driver resources

--- a/test/code/runners/base_runner.py
+++ b/test/code/runners/base_runner.py
@@ -21,7 +21,7 @@ class BaseRunner(ABC):
         self.failure_count = 0
 
     def reset_local_databases(self):
-        driver = TypeDB.driver(address=self.uri, credentials=Credentials(self.username,self.password), driver_options=DriverOptions(DriverTlsConfig.disabled()))
+        driver = TypeDB.driver(addresses=self.uri, credentials=Credentials(self.username,self.password), driver_options=DriverOptions(DriverTlsConfig.disabled()))
         for database in driver.databases.all():
             database.delete()
         for user in driver.users.all():

--- a/test/code/runners/python_requirements.txt
+++ b/test/code/runners/python_requirements.txt
@@ -1,1 +1,1 @@
-typedb-driver==3.10.0
+typedb-driver==3.11.0rc1

--- a/test/code/runners/rust_cargo_toml.toml
+++ b/test/code/runners/rust_cargo_toml.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 serde_json = "1.0.114"
-typedb-driver = { version = "3.10.0" }
+typedb-driver = { version = "3.11.0-rc1" }
 tokio = "1.43.0"
 futures-util = "0.3.31"


### PR DESCRIPTION
## Goal
Complete driver examples updates to match versions 3.11 and update the respective dependencies. Ensure CI jobs are fixed.

## Implementation
Update all the needed `requirements` and `dependencies` and finish the docs rewrite of the pieces missed in the previous PRs.