### PR TITLE
Add TypeDB schema modeling guide

### DIFF
--- a/core-concepts/modules/ROOT/pages/typeql/best-practices.adoc
+++ b/core-concepts/modules/ROOT/pages/typeql/best-practices.adoc
@@ -1,4 +1,0 @@
-= Best practices
-
-[placeholder]
-Best practices for using TypeQL. 

--- a/core-concepts/modules/ROOT/pages/typeql/index.adoc
+++ b/core-concepts/modules/ROOT/pages/typeql/index.adoc
@@ -48,14 +48,6 @@ Shows how various TypeQL clauses can be chained to form complex query & data mod
 TypeQL functions bring the familiar abstraction from programming languages to databases.
 ****
 
-// TODO:
-// .xref:{page-version}@core-concepts::typeql/best-practices.adoc[]
-// [.clickable]
-// ****
-// Best practices to get the most out of TypeQL's expressivity and TypeDB's safety guarantees
-// ****
-
-
 .xref:{page-version}@core-concepts::typeql/invalid-patterns.adoc[]
 [.clickable]
 ****

--- a/core-concepts/modules/ROOT/partials/nav.adoc
+++ b/core-concepts/modules/ROOT/partials/nav.adoc
@@ -20,7 +20,6 @@
 ** xref:{page-version}@core-concepts::typeql/query-clauses.adoc[]
 ** xref:{page-version}@core-concepts::typeql/queries-as-functions.adoc[]
 ** xref:{page-version}@core-concepts::typeql/invalid-patterns.adoc[]
-// ** xref:{page-version}@core-concepts::typeql/best-practices.adoc[]
 ** xref:{page-version}@core-concepts::typeql/glossary.adoc[]
 
 

--- a/guides/modules/ROOT/pages/index.adoc
+++ b/guides/modules/ROOT/pages/index.adoc
@@ -22,7 +22,7 @@ Learn how to write TypeQL queries
 .xref:{page-version}@guides::schema-modeling.adoc[]
 [.clickable]
 ****
-Design TypeDB schemas that are readable and as type-safe as you need
+Learn best practices for TypeDB schema design and data modeling
 ****
 --
 

--- a/guides/modules/ROOT/pages/index.adoc
+++ b/guides/modules/ROOT/pages/index.adoc
@@ -19,7 +19,7 @@ Integrate TypeDB into your application or platform
 Learn how to write TypeQL queries
 ****
 
-.xref:{page-version}@guides::modeling.adoc[]
+.xref:{page-version}@guides::schema-modeling.adoc[]
 [.clickable]
 ****
 Design TypeDB schemas that are readable and as type-safe as you need

--- a/guides/modules/ROOT/pages/index.adoc
+++ b/guides/modules/ROOT/pages/index.adoc
@@ -18,6 +18,12 @@ Integrate TypeDB into your application or platform
 ****
 Learn how to write TypeQL queries
 ****
+
+.xref:{page-version}@guides::modeling.adoc[]
+[.clickable]
+****
+Design TypeDB schemas that are readable and as type-safe as you need
+****
 --
 
 Got other guides you'd like to see?

--- a/guides/modules/ROOT/pages/modeling.adoc
+++ b/guides/modules/ROOT/pages/modeling.adoc
@@ -105,17 +105,17 @@ let $person in persons_by_name("Alice");
 
 == Entities, relations, and attributes
 
-TypeDB treats relations and attributes as first-class, alongside entities.
+TypeDB treats relations and attributes as first-class, alongside entities (see xref:{page-version}@core-concepts::typeql/entities-relations-attributes.adoc[] for the underlying data model).
 Choosing between the three is the first modeling decision for every piece of data:
 
-* Use an *entity* when the data has an independent existence, unrelated to any relationships or specific attributes.
+* Use an *entity* when the data has an independent existence — one that does not depend on any relationship or specific attribute.
 * Use a *relation* when the existence of the data depends on the linked role players.
 * Use an *attribute* for a piece of data entirely defined by its type and its value.
 
 === Relations depend on their players
 
 TypeDB auto-deletes any relation left with zero role players, even if it still has attributes.
-Here an employment is created with only an employer (the employee role is optional by default), and disappears when that employer is deleted:
+Here an employment is created with only an employer (each `relates` role defaults to `@card(0..1)`, making the employee role optional — see the Cardinality section below), and disappears when that employer is deleted:
 
 [,typeql]
 ----
@@ -150,7 +150,7 @@ Two further consequences of relations being first-class:
 
 === Attributes are immutable, global, and shared
 
-An attribute instance is entirely defined by its type and value, and is _immutable, global, shared, and linked against_.
+An attribute instance is entirely defined by its type and value, and is _immutable, global, shared, and linked against_: owners do not contain attributes, they link to them.
 A single `name "Alice"` exists in the entire database — unrelated owners all link to the same instance:
 
 [,typeql]
@@ -180,7 +180,7 @@ $x has name "Alice";  # the person and the company
 If you want to polymorphically query ownerships like this, a shared 'global' attribute is a good model.
 Otherwise, use a specific attribute with a single owner — it documents the narrower intent in the schema.
 
-Attributes default to *dependent*: an instance is automatically deleted when its last owner goes.
+Attributes default to *dependent*: an instance is automatically deleted when its last owner is deleted.
 Marking the attribute type xref:{page-version}@typeql-reference::annotations/independent.adoc[`@independent`] allows instances to exist freely — useful, for example, when pre-loading a dictionary of words or numbers:
 
 [,typeql]
@@ -191,7 +191,7 @@ define
 attribute word @independent, value string;
 ----
 
-Finally, an attribute carries a value of the value type assigned in the schema — but an abstract attribute may leave the value type unassigned.
+Finally, an attribute carries a value of the value type assigned in the schema — but an xref:{page-version}@typeql-reference::annotations/abstract.adoc[`@abstract`] attribute may leave the value type unassigned.
 A classic example is an abstract `id`, subtyped into concrete identifiers with different value types:
 
 [,typeql]
@@ -218,8 +218,8 @@ Both axes are resolved polymorphically at read time:
 * `$x isa person;` resolves *subtype polymorphism* — it matches `person` and everything below it.
 * `$x has name $n;` or `$r links (employee: $x);` resolve *interface polymorphism* — they match every type implementing the capability, as the `has name "Alice"` query above matched both a person and a company.
 
-A nice way to implement 'multi-typing' is to create unary relation types that act as components for a type.
-Here, a strongly-typed HR subsystem can be built against a person's `hr-component` — of which at most one can exist:
+Since a type cannot `sub` two parents, a nice way to implement 'multi-typing' is to create *unary relations* — relations with a single role — that act as components for a type.
+Here, a strongly typed HR subsystem can be built against a person's `hr-component` — of which at most one can exist:
 
 [,typeql]
 ----
@@ -268,7 +268,7 @@ attribute label, value string;
 entity thing, owns label @card(0..);
 ----
 
-Any kind of data fits without schema changes — but you trade off compiler errors for silent misses and data bugs.
+Any kind of data fits without schema changes — but you trade off type errors for silent misses and data bugs.
 A mistyped label is not an error; the query silently returns no results instead of failing:
 
 [,typeql]
@@ -306,7 +306,7 @@ attribute status, value string @values("active", "suspended");
 entity account, owns status;
 ----
 
-can be turned into unary relation types, and the system will validate the enums as types instead:
+can have its values turned into unary relation types, and the system will validate the enums as types instead:
 
 [,typeql]
 ----
@@ -344,7 +344,7 @@ More types buy you earlier errors and richer queries; less gets you flexibility.
 
 == Role subtyping
 
-Role types are defined within the "scope" of a relation type, but are thereafter true types: `relation employment, relates employee` creates a role type `employment:employee` that can be queried like any other.
+Role types are defined within the "scope" of a relation type, but are thereafter full-fledged types in their own right: `relation employment, relates employee` creates a role type `employment:employee` that can be queried like any other.
 
 Role types are inherited _as-is_: a `part-time-employment sub employment` inherits the role `employment:employee`.
 There is no distinct role `part-time-employment:employee` — it is the same `employment:employee`, held by `employment` and all of its subtypes.
@@ -557,10 +557,10 @@ $bot isa service-account,
 ----
 #!test[write, fail_at = commit]
 insert
-$bot isa service-account;  # no email: violates inherited @card(1..)
+$bot isa service-account;  # no email: violates both the inherited @card(1..) and the local @card(1)
 ----
 
-Under the hood, `@key` is a composition of xref:{page-version}@typeql-reference::annotations/unique.adoc[`@unique`] and `@card(1)`: `@unique` requires that no other instance of the owner type owns the specific attribute instance.
+Under the hood, `@key` is a composition of xref:{page-version}@typeql-reference::annotations/unique.adoc[`@unique`] and `@card(1)`: `@unique` requires that no two instances of the owner type (including its subtypes) own an attribute of that type with the same value.
 Both `@key` and `@unique` go on the ownership, not on the attribute definition.
 
 == Functions
@@ -569,11 +569,11 @@ Functions serve several distinct modeling purposes:
 
 1. *Modularizing* huge queries into named, reusable pieces.
 2. Performing *sub-queries and aggregates*.
-3. *Recursive* querying, with built-in loop detection and termination.
+3. *Recursive* querying, with built-in loop detection and termination (known as _tabling_ — see xref:{page-version}@guides::typeql/optimizing-typeql.adoc[Optimizing TypeQL]).
 4. Categorizing — creating *"conceptual relations"* that are computed rather than stored.
 
 The `persons_by_name` function in the naming section is an example of the first two.
-For the fourth, a function that returns a `boolean` can be queried like an anonymous relation — here, "is this person employed by this company?" is a derived fact, computed from `employment` rather than stored:
+For the fourth, a function that returns a `boolean` can be queried like a relation — here, "is this person employed by this company?" is a derived fact, computed from `employment` on the fly rather than stored:
 
 [,typeql]
 ----
@@ -610,5 +610,11 @@ The full semantics of cardinality and value constraints
 [.clickable]
 ****
 Reference for all schema annotations
+****
+
+.xref:{page-version}@core-concepts::typeql/queries-as-functions.adoc[]
+[.clickable]
+****
+Function signatures, streams, aggregates, and recursion in depth
 ****
 --

--- a/guides/modules/ROOT/pages/modeling.adoc
+++ b/guides/modules/ROOT/pages/modeling.adoc
@@ -1,0 +1,439 @@
+= Modeling
+:keywords: typedb, typeql, modeling, schema, naming, type safety, cardinality, constraints, guide
+:pageTitle: Modeling
+:summary: Design TypeDB schemas - naming, type safety, shared vs specific attributes, cardinality, and constraints.
+:page-toclevels: 2
+:test-typeql: linear
+
+== Overview
+
+This guide collects practical advice for designing TypeDB schemas:
+
+1. Naming types and functions so that queries read naturally.
+2. Choosing the level of type safety that fits your application.
+3. Deciding between shared, generic attributes and owner-specific ones.
+4. Picking the most specific cardinality for `owns`, `relates`, and `plays`.
+5. Placing value restrictions at the right level, and specializing inherited constraints.
+
+== Prerequisites
+
+This guide assumes you have access to a running TypeDB instance.
+We recommend using xref:{page-version}@tools::studio.adoc[TypeDB Studio] to follow along.
+
+The examples build up a single schema from top to bottom: types defined in earlier sections are reused and extended in later ones.
+
+== Naming types and functions
+
+TypeQL reads most elegantly when every type — entity, relation, role, and attribute — is named with a noun.
+The main TypeQL keywords (`isa`, `has`, `links`, `relates`, `owns`, `plays`) are verbs, so the types slot in as nouns around them, and queries read like English sentences.
+
+[,typeql]
+----
+#!test[schema, commit]
+define
+
+attribute name, value string;
+attribute salary, value double;
+
+entity person,
+    owns name,
+    plays employment:employee;
+
+entity company,
+    owns name,
+    plays employment:employer;
+
+relation employment,
+    relates employer,
+    relates employee,
+    owns salary;
+----
+
+*Attributes*: querying with `match ... has ...`, the object of the sentence comes after the `has`, so it reads best as a noun.
+Read aloud, `$person has name "Alice"` is a well-formed English sentence; a verb name like `named` would produce the awkward `$person has named "Alice"`.
+
+[,typeql]
+----
+#!test[write, commit, count = 1]
+insert
+$person isa person, has name "Alice";
+$company isa company, has name "TypeDB";
+$employment isa employment,
+    links (employer: $company, employee: $person),
+    has salary 100000.0;
+----
+
+*Relations*: querying with `match ... links ...`, the object of the sentence again comes after the verb, so a relation also reads best as a noun.
+
+[,typeql]
+----
+#!test[read, count = 1]
+match
+$employment isa employment,
+    links (employer: $company, employee: $person);
+----
+
+Relations read best as *active or verbal nouns* — the noun form of the action the relation captures.
+For example, `employment` is the noun form of _to employ_, `marriage` of _to marry_, and `assignment` of _to assign_.
+Sometimes the two coincide: `grant` is the noun form of _to grant_, and `review` of _to review_.
+Compare the verb-named alternative: `employs links (...)` reads as two verbs in a row, while `employment links ...` reads naturally.
+
+*Functions* should be named by what they return and the constraints they contain, e.g. `persons_by_name`, or `principals_with_access`:
+
+[,typeql]
+----
+#!test[schema, commit]
+define
+
+fun persons_by_name($name: string) -> { person }:
+    match
+        $person isa person, has name == $name;
+    return { $person };
+----
+
+The call site then reads as a description of the result:
+
+[,typeql]
+----
+#!test[read, count = 1]
+match
+let $person in persons_by_name("Alice");
+----
+
+== Type safety strictness
+
+TypeDB gives you the power to choose the level of type safety you want.
+The same domain can be modeled anywhere on a spectrum, from a single generic type with string labels to a fully enumerated schema where even enum values are types.
+
+At the loose end, you can choose to avoid defining specialized types altogether, and create an entity type `thing` with an attribute `label`:
+
+[,typeql]
+----
+#!test[schema, commit]
+define
+
+attribute label, value string;
+entity thing, owns label @card(0..);
+----
+
+Any kind of data fits without schema changes — but the schema can no longer catch your mistakes.
+A mistyped label is not an error; the query silently returns no results instead of failing:
+
+[,typeql]
+----
+#!test[write, commit, count = 1]
+insert
+$t isa thing, has label "person", has label "alice";
+----
+
+[,typeql]
+----
+#!test[read, count = 0]
+match
+$t isa thing, has label "perzon";  # typo: no error, just no results
+----
+
+Alternatively, you can choose to enumerate your types into the schema — like the `person` and `company` types above — and the database will type check those for you.
+The same typo is then an error, caught as soon as the query runs:
+
+[,typeql]
+----
+#!test[read, fail_at = runtime]
+match
+$p isa perzon;  # error: 'perzon' is not a defined type
+----
+
+At the strict end, even an attribute with an enumerated set of values — usually modeled with a xref:{page-version}@typeql-reference::annotations/values.adoc[`@values`] restriction —
+
+[,typeql]
+----
+#!test[schema, commit]
+define
+
+attribute status, value string @values("active", "suspended");
+entity account, owns status;
+----
+
+can be turned into unary relation types (relations with a single role), and the system will validate the enums as types instead:
+
+[,typeql]
+----
+#!test[schema, commit]
+define
+
+relation account-status @abstract, relates subject;
+relation active-status sub account-status;
+relation suspended-status sub account-status;
+
+entity account, plays account-status:subject @card(0..1);
+----
+
+Note the `@card(0..1)` on the `plays`: the default of `@card(0..)` would allow an account to be active and suspended at the same time, so we tighten it to match the single-valued `status` attribute it replaces.
+
+[,typeql]
+----
+#!test[write, commit, count = 1]
+insert
+$account isa account;
+$active isa active-status, links (subject: $account);
+----
+
+With the enum lifted into the type system, each state can later gain its own attributes and roles (e.g. a `suspended-status` owning a `reason`), and queries over states are type checked like any other pattern:
+
+[,typeql]
+----
+#!test[read, count = 1]
+match
+$status isa account-status, links (subject: $account);  # polymorphic over all states
+----
+
+How much type safety you need comes down to a trade-off: the size of the schema you are willing to manage, against the rigor with which your reads and writes are validated.
+More types buy you earlier errors and richer queries; less gets you flexibility.
+
+== Shared vs specific attributes
+
+When do you use a general `start-date` and share it across different owners, versus a `policy-start-date`, which is specific to one owner type?
+
+In practice, it is hard to find use cases where attributes are truly 'global'; attributes tend to fall into one of two categories:
+
+* If an attribute is a *first-class citizen*, such as `company-id`, sharing it exposes an interface — "company-id ownership" — that multiple things might implement.
+* If an attribute is purely an *embedded property* of one type, then it is effectively scoped to its owner, and specific naming makes that explicit.
+
+*Modeling guide*: if you want to polymorphically query ownerships, then the 'global' attribute is a good model for things to share.
+Otherwise, you can use a specific attribute with one owner.
+
+Here `start-date` is shared by two owner types, and `company-id` is an identifier interface implemented by both a company and the invoices that reference it:
+
+[,typeql]
+----
+#!test[schema, commit]
+define
+
+attribute start-date, value datetime;
+attribute company-id, value string;
+
+company owns company-id;
+employment owns start-date;
+
+entity invoice, owns company-id;
+entity policy, owns start-date;
+----
+
+[,typeql]
+----
+#!test[write, commit, count = 1]
+insert
+$person isa person;
+$company isa company, has company-id "C-001";
+$invoice isa invoice, has company-id "C-001";
+$employment isa employment,
+    links (employer: $company, employee: $person),
+    has start-date 2024-01-15T00:00:00;
+$policy isa policy, has start-date 2024-06-01T00:00:00;
+----
+
+The shared attribute is what enables polymorphic querying over every ownership — anything that started, regardless of its type, or everything connected to a given company id:
+
+[,typeql]
+----
+#!test[read, count = 2]
+match
+$x has start-date $date;
+----
+
+[,typeql]
+----
+#!test[read, count = 2]
+match
+$x has company-id "C-001";
+----
+
+If you never intend to query the ownership polymorphically, a specific attribute with one owner (e.g. `policy-start-date` owned only by `policy`) documents that intent in the schema, and cannot accidentally be attached to — or matched against — any other type.
+
+[NOTE]
+====
+A possible future direction for the embedded-property case is *scoped attributes*: an entity `policy` declaring a `start-date` scoped to its owner (`policy.start-date`), without inventing a globally unique name.
+====
+
+== Cardinality
+
+Use the most specific possible xref:{page-version}@typeql-reference::annotations/card.adoc[cardinality] for every capability in your schema.
+The defaults are permissive:
+
+.Default capability cardinalities
+[cols="1,1",options="header"]
+|===
+| Capability | Default cardinality
+
+| `owns` | `@card(0..1)`
+| `relates` | `@card(0..1)`
+| `plays` | `@card(0..)`
+|===
+
+The only way to encode a *required* connection is a cardinality with a lower bound of at least one, e.g. `@card(1)` or `@card(1..)`.
+Note that xref:{page-version}@typeql-reference::annotations/key.adoc[`@key`] implies cardinality 1 as well (and therefore cannot be combined with `@card`).
+
+For most relations, tighten the default `@card(0..1)` on each `relates` role to `@card(1)`, unless the role is genuinely optional — an account holding without an account is rarely meaningful:
+
+[,typeql]
+----
+#!test[schema, commit]
+define
+
+relation account-holding,
+    relates holder @card(1),
+    relates account @card(1);
+
+person plays account-holding:holder;
+account plays account-holding:account;
+----
+
+A complete account holding commits fine:
+
+[,typeql]
+----
+#!test[write, commit, count = 1]
+match
+$person isa person, has name "Alice";
+insert
+$account isa account;
+$holding isa account-holding,
+    links (holder: $person, account: $account);
+----
+
+A holding missing its account now fails commit-time validation instead of silently persisting incomplete data:
+
+[,typeql]
+----
+#!test[write, fail_at = commit]
+match
+$person isa person, has name "Alice";
+insert
+$holding isa account-holding, links (holder: $person);  # no account: rejected at commit
+----
+
+The same applies to `owns`: `@card(1)` makes an attribute mandatory, `@card(1..)` requires at least one, and `@key` both requires exactly one and enforces uniqueness:
+
+[,typeql]
+----
+#!test[schema, commit]
+define
+
+attribute subscription-id, value string;
+attribute expiry, value datetime;
+
+entity subscription,
+    owns subscription-id @key,
+    owns expiry @card(1);
+----
+
+[,typeql]
+----
+#!test[write, fail_at = commit]
+insert
+$sub isa subscription, has subscription-id "S-001";  # missing required expiry: rejected
+----
+
+== Constraints
+
+Value restrictions like `@values` and xref:{page-version}@typeql-reference::annotations/range.adoc[`@range`] can be declared on the `attribute` definition itself, where they constrain every use of the attribute — or locally on an individual `owns`, where they constrain only that owner.
+Declaring them at the `owns` level lets a single generic attribute carry different restrictions for different owners:
+
+[,typeql]
+----
+#!test[schema, commit]
+define
+
+attribute rating, value integer;
+
+entity restaurant, owns rating @range(1..5);
+entity movie, owns rating @range(1..10);
+----
+
+Both owners share the same `rating` attribute — enabling polymorphic queries over ratings — but each is validated against its own range, and a violation is rejected as soon as the insert runs:
+
+[,typeql]
+----
+#!test[write, commit, count = 1]
+insert
+$movie isa movie, has rating 9;  # valid for movie
+----
+
+[,typeql]
+----
+#!test[write, fail_at = runtime]
+insert
+$restaurant isa restaurant, has rating 9;  # out of range for restaurant: rejected
+----
+
+Subtypes can add their own specializations of inherited capabilities, and both the local and the inherited constraints are validated at commit time.
+For example, if an `identity` is required to have at least one `email`, a subtype `service-account` can restrict that to exactly one:
+
+[,typeql]
+----
+#!test[schema, commit]
+define
+
+attribute email, value string;
+
+entity identity @abstract,
+    owns email @card(1..);
+
+entity user sub identity;
+
+entity service-account sub identity,
+    owns email @card(1);
+----
+
+All identities are validated against locally defined and inherited constraints on the capability.
+A `user` only carries the inherited `@card(1..)`, so multiple emails are fine:
+
+[,typeql]
+----
+#!test[write, commit, count = 1]
+insert
+$user isa user,
+    has email "alice@typedb.com",
+    has email "alice@example.com";
+----
+
+A `service-account` is checked against both the inherited `@card(1..)` and its local `@card(1)` — so two emails and zero emails are both rejected:
+
+[,typeql]
+----
+#!test[write, fail_at = commit]
+insert
+$bot isa service-account,
+    has email "bot@typedb.com",
+    has email "bot-backup@typedb.com";  # two emails: violates local @card(1)
+----
+
+[,typeql]
+----
+#!test[write, fail_at = commit]
+insert
+$bot isa service-account;  # no email: violates inherited @card(1..)
+----
+
+== Further reading
+
+[cols-2]
+--
+.xref:{page-version}@core-concepts::typeql/constraining-data.adoc[]
+[.clickable]
+****
+The full semantics of cardinality and value constraints
+****
+
+.xref:{page-version}@typeql-reference::annotations/index.adoc[]
+[.clickable]
+****
+Reference for all schema annotations
+****
+
+.xref:{page-version}@academy::9-modeling-schemas/index.adoc[]
+[.clickable]
+****
+A structured course on schema modeling
+****
+--

--- a/guides/modules/ROOT/pages/modeling.adoc
+++ b/guides/modules/ROOT/pages/modeling.adoc
@@ -1,7 +1,7 @@
 = Modeling
-:keywords: typedb, typeql, modeling, schema, naming, entities, relations, attributes, composition, type safety, cardinality, constraints, functions, guide
+:keywords: typedb, typeql, modeling, schema, entities, relations, attributes, naming, composition, type safety, cardinality, constraints, functions, guide
 :pageTitle: Modeling
-:summary: Design TypeDB schemas - naming, entities vs relations vs attributes, composition, type safety, role subtyping, cardinality, constraints, and functions.
+:summary: Design TypeDB schemas - entities vs relations vs attributes, naming, composition, type safety, role subtyping, cardinality, constraints, and functions.
 :page-toclevels: 2
 :test-typeql: linear
 
@@ -9,8 +9,8 @@
 
 This guide collects practical advice for designing TypeDB schemas:
 
-1. Naming types and functions so that queries read naturally.
-2. Choosing between entities, relations, and attributes.
+1. Choosing between entities, relations, and attributes.
+2. Naming types and functions so that queries read naturally.
 3. Composing types out of capabilities instead of deep hierarchies.
 4. Choosing the level of type safety that fits your application.
 5. Specializing roles in relation hierarchies.
@@ -25,10 +25,17 @@ We recommend using xref:{page-version}@tools::studio.adoc[TypeDB Studio] to foll
 
 The examples build up a single schema from top to bottom: types defined in earlier sections are reused and extended in later ones.
 
-== Naming types and functions
+== Entities, relations, and attributes
 
-TypeQL reads most elegantly when every type — entity, relation, role, and attribute — is named with a noun.
-The main TypeQL keywords (`isa`, `has`, `links`, `relates`, `owns`, `plays`) are verbs, so the types slot in as nouns around them, and queries read like English sentences.
+TypeDB treats relations and attributes as first-class, alongside entities (see xref:{page-version}@core-concepts::typeql/entities-relations-attributes.adoc[] for the underlying data model).
+Choosing between the three is the first modeling decision for every piece of data:
+
+* Use an *entity* when the data has an independent existence in the real world — a person, a project, a movie — one that does not depend on any relationship or specific attribute, and is not trivially representable by a single value.
+Entities are the basic building blocks of any TypeDB schema.
+* Use a *relation* when the data only exists because of a connection between other things — a product order, a group membership, an access grant — so its existence depends on the linked role players.
+* Use an *attribute* when the data is just a value — a size, a date, a name — entirely defined by its type and its value.
+
+Applying the rule to a small employment domain gives the schema this guide builds on:
 
 [,typeql]
 ----
@@ -52,9 +59,6 @@ relation employment,
     owns salary;
 ----
 
-*Attributes*: querying with `match ... has ...`, the object of the sentence comes after the `has`, so it reads best as a noun.
-Read aloud, `$person has name "Alice"` is a well-formed English sentence; a verb name like `named` would produce the awkward `$person has named "Alice"`.
-
 [,typeql]
 ----
 #!test[write, commit, count = 1]
@@ -65,52 +69,6 @@ $employment isa employment,
     links (employer: $company, employee: $person),
     has salary 100000.0;
 ----
-
-*Relations*: querying with `match ... links ...`, the object of the sentence again comes after the verb, so a relation also reads best as a noun.
-
-[,typeql]
-----
-#!test[read, count = 1]
-match
-$employment isa employment,
-    links (employer: $company, employee: $person);
-----
-
-Relations read best as *active or verbal nouns* — the noun form of the action the relation captures.
-For example, `employment` is the noun form of _to employ_, `marriage` of _to marry_, and `assignment` of _to assign_.
-Sometimes the two coincide: `grant` is the noun form of _to grant_, and `review` of _to review_.
-Compare the verb-named alternative: `employs links (...)` reads as two verbs in a row, while `employment links ...` reads naturally.
-
-*Functions* should be named by what they return and the constraints they contain, e.g. `persons_by_name`, or `principals_with_access`:
-
-[,typeql]
-----
-#!test[schema, commit]
-define
-
-fun persons_by_name($name: string) -> { person }:
-    match
-        $person isa person, has name == $name;
-    return { $person };
-----
-
-The call site then reads as a description of the result:
-
-[,typeql]
-----
-#!test[read, count = 1]
-match
-let $person in persons_by_name("Alice");
-----
-
-== Entities, relations, and attributes
-
-TypeDB treats relations and attributes as first-class, alongside entities (see xref:{page-version}@core-concepts::typeql/entities-relations-attributes.adoc[] for the underlying data model).
-Choosing between the three is the first modeling decision for every piece of data:
-
-* Use an *entity* when the data has an independent existence — one that does not depend on any relationship or specific attribute.
-* Use a *relation* when the existence of the data depends on the linked role players.
-* Use an *attribute* for a piece of data entirely defined by its type and its value.
 
 === Relations depend on their players
 
@@ -204,10 +162,65 @@ attribute email-id sub id, value string;
 attribute employee-id sub id, value integer;
 ----
 
+== Naming types and functions
+
+TypeQL reads most elegantly when every type — entity, relation, role, and attribute — is named with a noun.
+The main TypeQL keywords (`isa`, `has`, `links`, `relates`, `owns`, `plays`) are verbs, so the types slot in as nouns around them, and queries read like English sentences.
+
+*All types*: querying with `match ... isa ...` reads as "X is a Y", and the type's label fills the Y slot — `$person isa person` works as a sentence because the label is a noun.
+
+*Attributes*: querying with `match ... has ...`, the object of the sentence comes after the `has`, so it reads best as a noun.
+Read aloud, `$person has name "Alice"` is a well-formed English sentence; a verb name like `named` would produce the awkward `$person has named "Alice"`.
+
+[,typeql]
+----
+#!test[read, count = 1]
+match
+$person isa person, has name "Alice";
+----
+
+*Relations*: querying with `match ... links ...`, the object of the sentence again comes after the verb, so a relation also reads best as a noun.
+
+[,typeql]
+----
+#!test[read, count = 1]
+match
+$employment isa employment,
+    links (employer: $company, employee: $person);
+----
+
+Relations read best as *active or verbal nouns* — the noun form of the action the relation captures.
+For example, `employment` is the noun form of _to employ_, `marriage` of _to marry_, and `assignment` of _to assign_.
+Sometimes the two coincide: `grant` is the noun form of _to grant_, and `review` of _to review_.
+Compare the verb-named alternative: `employs links (...)` reads as two verbs in a row, while `employment links ...` reads naturally.
+
+*Functions* should be named by what they return and the constraints they contain, e.g. `persons_by_name`, or `principals_with_access`:
+
+[,typeql]
+----
+#!test[schema, commit]
+define
+
+fun persons_by_name($name: string) -> { person }:
+    match
+        $person isa person, has name == $name;
+    return { $person };
+----
+
+The call site then reads as a description of the result:
+
+[,typeql]
+----
+#!test[read, count = 1]
+match
+let $person in persons_by_name("Alice");
+----
+
 == Subtyping vs composition
 
 TypeDB supports only single inheritance.
 Treat `sub` as a true, independent "is-a" axis — and compose everything else.
+When a supertype exists only to be specialized, mark it xref:{page-version}@typeql-reference::annotations/abstract.adoc[`@abstract`] so that only its subtypes can have instances — as with the abstract `id` attribute above.
 
 To compose, we add linked relations and play roles: a role that a type plays acts as a _trait_ or _interface_, much like implementing a component architecture in OOP.
 We might have a plain `entity person`, but a person can behave as an employee — `entity person, plays employment:employee`.
@@ -595,6 +608,8 @@ $person isa person, has name "Alice";
 $company isa company, has name "TypeDB";
 true == person_employed($person, $company);
 ----
+
+Judicious use of functions helps minimize code duplication and optimizes for readability and maintainability — especially in larger schemas.
 
 == Further reading
 

--- a/guides/modules/ROOT/pages/modeling.adoc
+++ b/guides/modules/ROOT/pages/modeling.adoc
@@ -1,7 +1,7 @@
 = Modeling
-:keywords: typedb, typeql, modeling, schema, naming, type safety, cardinality, constraints, guide
+:keywords: typedb, typeql, modeling, schema, naming, entities, relations, attributes, composition, type safety, cardinality, constraints, functions, guide
 :pageTitle: Modeling
-:summary: Design TypeDB schemas - naming, type safety, shared vs specific attributes, cardinality, and constraints.
+:summary: Design TypeDB schemas - naming, entities vs relations vs attributes, composition, type safety, role subtyping, cardinality, constraints, and functions.
 :page-toclevels: 2
 :test-typeql: linear
 
@@ -10,10 +10,13 @@
 This guide collects practical advice for designing TypeDB schemas:
 
 1. Naming types and functions so that queries read naturally.
-2. Choosing the level of type safety that fits your application.
-3. Deciding between shared, generic attributes and owner-specific ones.
-4. Picking the most specific cardinality for `owns`, `relates`, and `plays`.
-5. Placing value restrictions at the right level, and specializing inherited constraints.
+2. Choosing between entities, relations, and attributes.
+3. Composing types out of capabilities instead of deep hierarchies.
+4. Choosing the level of type safety that fits your application.
+5. Specializing roles in relation hierarchies.
+6. Picking the most specific cardinality for `owns`, `relates`, and `plays`.
+7. Placing value restrictions at the right level, and specializing inherited constraints.
+8. Using functions for modularity, aggregation, recursion, and derived facts.
 
 == Prerequisites
 
@@ -100,6 +103,155 @@ match
 let $person in persons_by_name("Alice");
 ----
 
+== Entities, relations, and attributes
+
+TypeDB treats relations and attributes as first-class, alongside entities.
+Choosing between the three is the first modeling decision for every piece of data:
+
+* Use an *entity* when the data has an independent existence, unrelated to any relationships or specific attributes.
+* Use a *relation* when the existence of the data depends on the linked role players.
+* Use an *attribute* for a piece of data entirely defined by its type and its value.
+
+=== Relations depend on their players
+
+TypeDB auto-deletes any relation left with zero role players, even if it still has attributes.
+Here an employment is created with only an employer (the employee role is optional by default), and disappears when that employer is deleted:
+
+[,typeql]
+----
+#!test[write, commit, count = 1]
+insert
+$acme isa company, has name "Acme";
+$employment isa employment,
+    links (employer: $acme),
+    has salary 1.0;
+----
+
+[,typeql]
+----
+#!test[write, commit]
+match
+$company isa company, has name "Acme";
+delete
+$company;
+----
+
+[,typeql]
+----
+#!test[read, count = 0]
+match
+$employment isa employment, has salary 1.0;  # auto-deleted with its last player
+----
+
+Two further consequences of relations being first-class:
+
+* Relations are *n-ary*, meaning you never need to reify relationships — extend a relation with another role instead of inventing a linking entity.
+* Relations can be *nested*: a relation can itself be a role player in another relation.
+
+=== Attributes are immutable, global, and shared
+
+An attribute instance is entirely defined by its type and value, and is _immutable, global, shared, and linked against_.
+A single `name "Alice"` exists in the entire database — unrelated owners all link to the same instance:
+
+[,typeql]
+----
+#!test[write, commit, count = 1]
+insert
+$company isa company, has name "Alice";  # a company also named Alice
+----
+
+[,typeql]
+----
+#!test[read, count = 1]
+match
+$name isa name;
+$name == "Alice";  # one shared attribute instance, despite two owners
+----
+
+Sharing an attribute type across owners is what enables polymorphic querying over ownerships:
+
+[,typeql]
+----
+#!test[read, count = 2]
+match
+$x has name "Alice";  # the person and the company
+----
+
+If you want to polymorphically query ownerships like this, a shared 'global' attribute is a good model.
+Otherwise, use a specific attribute with a single owner — it documents the narrower intent in the schema.
+
+Attributes default to *dependent*: an instance is automatically deleted when its last owner goes.
+Marking the attribute type xref:{page-version}@typeql-reference::annotations/independent.adoc[`@independent`] allows instances to exist freely — useful, for example, when pre-loading a dictionary of words or numbers:
+
+[,typeql]
+----
+#!test[schema, commit]
+define
+
+attribute word @independent, value string;
+----
+
+Finally, an attribute carries a value of the value type assigned in the schema — but an abstract attribute may leave the value type unassigned.
+A classic example is an abstract `id`, subtyped into concrete identifiers with different value types:
+
+[,typeql]
+----
+#!test[schema, commit]
+define
+
+attribute id @abstract;
+attribute email-id sub id, value string;
+attribute employee-id sub id, value integer;
+----
+
+== Subtyping vs composition
+
+TypeDB supports only single inheritance.
+Treat `sub` as a true, independent "is-a" axis — and compose everything else.
+
+To compose, we add linked relations and play roles: a role that a type plays acts as a _trait_ or _interface_, much like implementing a component architecture in OOP.
+We might have a plain `entity person`, but a person can behave as an employee — `entity person, plays employment:employee`.
+Attribute ownerships are interfaces the same way: `entity person, owns name` indicates a person can act as a "name-owner".
+
+Both axes are resolved polymorphically at read time:
+
+* `$x isa person;` resolves *subtype polymorphism* — it matches `person` and everything below it.
+* `$x has name $n;` or `$r links (employee: $x);` resolve *interface polymorphism* — they match every type implementing the capability, as the `has name "Alice"` query above matched both a person and a company.
+
+A nice way to implement 'multi-typing' is to create unary relation types that act as components for a type.
+Here, a strongly-typed HR subsystem can be built against a person's `hr-component` — of which at most one can exist:
+
+[,typeql]
+----
+#!test[schema, commit]
+define
+
+relation hr-component,
+    relates employee;
+
+person plays hr-component:employee @card(0..1);
+----
+
+[,typeql]
+----
+#!test[write, commit, count = 1]
+match
+$person isa person, has name "Alice";
+insert
+$hr isa hr-component, links (employee: $person);
+----
+
+The `@card(0..1)` on the `plays` makes the component single-valued — attaching a second one is rejected:
+
+[,typeql]
+----
+#!test[write, fail_at = commit]
+match
+$person isa person, has name "Alice";
+insert
+$hr isa hr-component, links (employee: $person);  # second component: rejected at commit
+----
+
 == Type safety strictness
 
 TypeDB gives you the power to choose the level of type safety you want.
@@ -116,7 +268,7 @@ attribute label, value string;
 entity thing, owns label @card(0..);
 ----
 
-Any kind of data fits without schema changes — but the schema can no longer catch your mistakes.
+Any kind of data fits without schema changes — but you trade off compiler errors for silent misses and data bugs.
 A mistyped label is not an error; the query silently returns no results instead of failing:
 
 [,typeql]
@@ -154,7 +306,7 @@ attribute status, value string @values("active", "suspended");
 entity account, owns status;
 ----
 
-can be turned into unary relation types (relations with a single role), and the system will validate the enums as types instead:
+can be turned into unary relation types, and the system will validate the enums as types instead:
 
 [,typeql]
 ----
@@ -190,70 +342,63 @@ $status isa account-status, links (subject: $account);  # polymorphic over all s
 How much type safety you need comes down to a trade-off: the size of the schema you are willing to manage, against the rigor with which your reads and writes are validated.
 More types buy you earlier errors and richer queries; less gets you flexibility.
 
-== Shared vs specific attributes
+== Role subtyping
 
-When do you use a general `start-date` and share it across different owners, versus a `policy-start-date`, which is specific to one owner type?
+Role types are defined within the "scope" of a relation type, but are thereafter true types: `relation employment, relates employee` creates a role type `employment:employee` that can be queried like any other.
 
-In practice, it is hard to find use cases where attributes are truly 'global'; attributes tend to fall into one of two categories:
+Role types are inherited _as-is_: a `part-time-employment sub employment` inherits the role `employment:employee`.
+There is no distinct role `part-time-employment:employee` — it is the same `employment:employee`, held by `employment` and all of its subtypes.
 
-* If an attribute is a *first-class citizen*, such as `company-id`, sharing it exposes an interface — "company-id ownership" — that multiple things might implement.
-* If an attribute is purely an *embedded property* of one type, then it is effectively scoped to its owner, and specific naming makes that explicit.
-
-*Modeling guide*: if you want to polymorphically query ownerships, then the 'global' attribute is a good model for things to share.
-Otherwise, you can use a specific attribute with one owner.
-
-Here `start-date` is shared by two owner types, and `company-id` is an identifier interface implemented by both a company and the invoices that reference it:
+To create a specialized role just for the sub-relation type, create a role subtype with `as`:
 
 [,typeql]
 ----
 #!test[schema, commit]
 define
 
-attribute start-date, value datetime;
-attribute company-id, value string;
+relation part-time-employment sub employment,
+    relates part-time-employee as employee;
 
-company owns company-id;
-employment owns start-date;
-
-entity invoice, owns company-id;
-entity policy, owns start-date;
+person plays part-time-employment:part-time-employee;
 ----
+
+This essentially creates a new role type `part-time-employment:part-time-employee sub employment:employee`, and also blocks the inherited `employee` role in `part-time-employment` instances.
+Note that `plays` declarations are not inherited across the specialization — players of the new role need their own `plays`.
 
 [,typeql]
 ----
 #!test[write, commit, count = 1]
+match
+$company isa company, has name "TypeDB";
 insert
-$person isa person;
-$company isa company, has company-id "C-001";
-$invoice isa invoice, has company-id "C-001";
-$employment isa employment,
-    links (employer: $company, employee: $person),
-    has start-date 2024-01-15T00:00:00;
-$policy isa policy, has start-date 2024-06-01T00:00:00;
+$person isa person, has name "Bob";
+$employment isa part-time-employment,
+    links (employer: $company, part-time-employee: $person);
 ----
 
-The shared attribute is what enables polymorphic querying over every ownership — anything that started, regardless of its type, or everything connected to a given company id:
+Because of the role subtyping, querying the parent role at read time also resolves players of the specialized role:
 
 [,typeql]
 ----
 #!test[read, count = 2]
 match
-$x has start-date $date;
+$employment isa employment, links (employee: $x);  # Alice (employee) and Bob (part-time-employee)
 ----
+
+The inherited `employee` role, however, can no longer be used in `part-time-employment` instances — the specialization blocks it:
 
 [,typeql]
 ----
-#!test[read, count = 2]
+#!test[write, fail_at = runtime]
 match
-$x has company-id "C-001";
+$person isa person, has name "Bob";
+$company isa company, has name "TypeDB";
+insert
+$employment isa part-time-employment,
+    links (employer: $company, employee: $person);  # blocked: use part-time-employee
 ----
 
-If you never intend to query the ownership polymorphically, a specific attribute with one owner (e.g. `policy-start-date` owned only by `policy`) documents that intent in the schema, and cannot accidentally be attached to — or matched against — any other type.
-
-[NOTE]
-====
-A possible future direction for the embedded-property case is *scoped attributes*: an entity `policy` declaring a `start-date` scoped to its owner (`policy.start-date`), without inventing a globally unique name.
-====
+The cost of a specialized role is that a new name must be created for it.
 
 == Cardinality
 
@@ -413,6 +558,42 @@ $bot isa service-account,
 #!test[write, fail_at = commit]
 insert
 $bot isa service-account;  # no email: violates inherited @card(1..)
+----
+
+Under the hood, `@key` is a composition of xref:{page-version}@typeql-reference::annotations/unique.adoc[`@unique`] and `@card(1)`: `@unique` requires that no other instance of the owner type owns the specific attribute instance.
+Both `@key` and `@unique` go on the ownership, not on the attribute definition.
+
+== Functions
+
+Functions serve several distinct modeling purposes:
+
+1. *Modularizing* huge queries into named, reusable pieces.
+2. Performing *sub-queries and aggregates*.
+3. *Recursive* querying, with built-in loop detection and termination.
+4. Categorizing — creating *"conceptual relations"* that are computed rather than stored.
+
+The `persons_by_name` function in the naming section is an example of the first two.
+For the fourth, a function that returns a `boolean` can be queried like an anonymous relation — here, "is this person employed by this company?" is a derived fact, computed from `employment` rather than stored:
+
+[,typeql]
+----
+#!test[schema, commit]
+define
+
+fun person_employed($person: person, $company: company) -> boolean:
+    match
+        $employment isa employment,
+            links (employer: $company, employee: $person);
+    return check;
+----
+
+[,typeql]
+----
+#!test[read, count = 1]
+match
+$person isa person, has name "Alice";
+$company isa company, has name "TypeDB";
+true == person_employed($person, $company);
 ----
 
 == Further reading

--- a/guides/modules/ROOT/pages/modeling.adoc
+++ b/guides/modules/ROOT/pages/modeling.adoc
@@ -139,15 +139,7 @@ If you want to polymorphically query ownerships like this, a shared 'global' att
 Otherwise, use a specific attribute with a single owner — it documents the narrower intent in the schema.
 
 Attributes default to *dependent*: an instance is automatically deleted when its last owner is deleted.
-Marking the attribute type xref:{page-version}@typeql-reference::annotations/independent.adoc[`@independent`] allows instances to exist freely — useful, for example, when pre-loading a dictionary of words or numbers:
-
-[,typeql]
-----
-#!test[schema, commit]
-define
-
-attribute word @independent, value string;
-----
+Marking the attribute type xref:{page-version}@typeql-reference::annotations/independent.adoc[`@independent`] allows instances to exist freely — useful, for example, when pre-loading a dictionary of words or numbers.
 
 Finally, an attribute carries a value of the value type assigned in the schema — but an xref:{page-version}@typeql-reference::annotations/abstract.adoc[`@abstract`] attribute may leave the value type unassigned.
 A classic example is an abstract `id`, subtyped into concrete identifiers with different value types:

--- a/guides/modules/ROOT/pages/modeling.adoc
+++ b/guides/modules/ROOT/pages/modeling.adoc
@@ -430,10 +430,4 @@ The full semantics of cardinality and value constraints
 ****
 Reference for all schema annotations
 ****
-
-.xref:{page-version}@academy::9-modeling-schemas/index.adoc[]
-[.clickable]
-****
-A structured course on schema modeling
-****
 --

--- a/guides/modules/ROOT/pages/schema-modeling.adoc
+++ b/guides/modules/ROOT/pages/schema-modeling.adoc
@@ -108,7 +108,7 @@ Two further consequences of relations being first-class:
 
 === Attributes are immutable, global, and shared
 
-An attribute instance is entirely defined by its type and value, and is _immutable, global, shared, and linked against_: owners do not contain attributes, they link to them.
+An attribute instance is entirely defined by its type and value, and it is _immutable, global, and shared_: owners do not contain attributes, they link to them.
 A single `name "Alice"` exists in the entire database — unrelated owners all link to the same instance:
 
 [,typeql]
@@ -214,7 +214,7 @@ TypeDB supports only single inheritance.
 Treat `sub` as a true, independent "is-a" axis — and compose everything else.
 When a supertype exists only to be specialized, mark it xref:{page-version}@typeql-reference::annotations/abstract.adoc[`@abstract`] so that only its subtypes can have instances — as with the abstract `id` attribute above.
 
-To compose, we add linked relations and play roles: a role that a type plays acts as a _trait_ or _interface_, much like implementing a component architecture in OOP.
+To compose, use relations and roles: a role that a type plays acts as a _trait_ or _interface_, much like a component architecture in OOP.
 We might have a plain `entity person`, but a person can behave as an employee — `entity person, plays employment:employee`.
 Attribute ownerships are interfaces the same way: `entity person, owns name` indicates a person can act as a "name-owner".
 
@@ -223,7 +223,7 @@ Both axes are resolved polymorphically at read time:
 * `$x isa person;` resolves *subtype polymorphism* — it matches `person` and everything below it.
 * `$x has name $n;` or `$r links (employee: $x);` resolve *interface polymorphism* — they match every type implementing the capability, as the `has name "Alice"` query above matched both a person and a company.
 
-Since a type cannot `sub` two parents, a nice way to implement 'multi-typing' is to create *unary relations* — relations with a single role — that act as components for a type.
+Since a type cannot `sub` two parents, a nice way to give one type several independent capabilities is to create *unary relations* — relations with a single role — that act as components for the type.
 Here, a strongly typed HR subsystem can be built against a person's `hr_component` — of which at most one can exist:
 
 [,typeql]
@@ -232,9 +232,9 @@ Here, a strongly typed HR subsystem can be built against a person's `hr_componen
 define
 
 relation hr_component,
-    relates employee;
+    relates subject;
 
-person plays hr_component:employee @card(0..1);
+person plays hr_component:subject @card(0..1);
 ----
 
 [,typeql]
@@ -243,7 +243,7 @@ person plays hr_component:employee @card(0..1);
 match
 $person isa person, has name "Alice";
 insert
-$hr isa hr_component, links (employee: $person);
+$hr isa hr_component, links (subject: $person);
 ----
 
 The HR subsystem can then look up a person's component and work against it:
@@ -253,7 +253,7 @@ The HR subsystem can then look up a person's component and work against it:
 #!test[read, count = 1]
 match
 $person isa person, has name "Alice";
-$as_hr isa hr_component, links (employee: $person);
+$as_hr isa hr_component, links (subject: $person);
 ----
 
 == Type safety strictness
@@ -299,7 +299,7 @@ match
 $p isa perzon;  # error: 'perzon' is not a defined type
 ----
 
-At the strict end, even an attribute with an enumerated set of values — usually modeled with a xref:{page-version}@typeql-reference::annotations/values.adoc[`@values`] restriction —
+At the strict end, consider an attribute with an enumerated set of values, usually modeled with a xref:{page-version}@typeql-reference::annotations/values.adoc[`@values`] restriction:
 
 [,typeql]
 ----
@@ -310,7 +310,7 @@ attribute status, value string @values("active", "suspended");
 entity account, owns status;
 ----
 
-can have its values turned into unary relation types, and the system will validate the enums as types instead:
+Those values can instead be turned into unary relation types, and the system will validate the enums as types:
 
 [,typeql]
 ----
@@ -514,7 +514,6 @@ entity service_account sub identity,
     owns email @card(1);
 ----
 
-All identities are validated against locally defined and inherited constraints on the capability.
 A `user` only carries the inherited `@card(1..)`, so multiple emails are fine:
 
 [,typeql]
@@ -556,7 +555,7 @@ Functions serve several distinct modeling purposes:
 3. *Recursive* querying, with built-in loop detection and termination (known as _tabling_ — see xref:{page-version}@guides::typeql/optimizing-typeql.adoc[Optimizing TypeQL]).
 4. Categorizing — creating *"conceptual relations"* that are computed rather than stored.
 
-The `persons_by_name` function in the naming section is an example of the first two.
+The `persons_by_name` function in the naming section is an example of the first — and calling it inside a larger `match` makes it a sub-query.
 For the fourth, a function that returns a `boolean` can be queried like a relation — here, "is this person employed by this company?" is a derived fact, computed from `employment` on the fly rather than stored:
 
 [,typeql]

--- a/guides/modules/ROOT/pages/schema-modeling.adoc
+++ b/guides/modules/ROOT/pages/schema-modeling.adoc
@@ -1,6 +1,6 @@
-= Modeling
+= Schema modeling
 :keywords: typedb, typeql, modeling, schema, entities, relations, attributes, naming, composition, type safety, cardinality, constraints, functions, guide
-:pageTitle: Modeling
+:pageTitle: Schema modeling
 :summary: Design TypeDB schemas - entities vs relations vs attributes, naming, composition, type safety, role subtyping, cardinality, constraints, and functions.
 :page-toclevels: 2
 :test-typeql: linear
@@ -150,8 +150,8 @@ A classic example is an abstract `id`, subtyped into concrete identifiers with d
 define
 
 attribute id @abstract;
-attribute email-id sub id, value string;
-attribute employee-id sub id, value integer;
+attribute email_id sub id, value string;
+attribute employee_id sub id, value integer;
 ----
 
 == Naming types and functions
@@ -224,17 +224,17 @@ Both axes are resolved polymorphically at read time:
 * `$x has name $n;` or `$r links (employee: $x);` resolve *interface polymorphism* — they match every type implementing the capability, as the `has name "Alice"` query above matched both a person and a company.
 
 Since a type cannot `sub` two parents, a nice way to implement 'multi-typing' is to create *unary relations* — relations with a single role — that act as components for a type.
-Here, a strongly typed HR subsystem can be built against a person's `hr-component` — of which at most one can exist:
+Here, a strongly typed HR subsystem can be built against a person's `hr_component` — of which at most one can exist:
 
 [,typeql]
 ----
 #!test[schema, commit]
 define
 
-relation hr-component,
+relation hr_component,
     relates employee;
 
-person plays hr-component:employee @card(0..1);
+person plays hr_component:employee @card(0..1);
 ----
 
 [,typeql]
@@ -243,18 +243,17 @@ person plays hr-component:employee @card(0..1);
 match
 $person isa person, has name "Alice";
 insert
-$hr isa hr-component, links (employee: $person);
+$hr isa hr_component, links (employee: $person);
 ----
 
-The `@card(0..1)` on the `plays` makes the component single-valued — attaching a second one is rejected:
+The HR subsystem can then look up a person's component and work against it:
 
 [,typeql]
 ----
-#!test[write, fail_at = commit]
+#!test[read, count = 1]
 match
 $person isa person, has name "Alice";
-insert
-$hr isa hr-component, links (employee: $person);  # second component: rejected at commit
+$as_hr isa hr_component, links (employee: $person);
 ----
 
 == Type safety strictness
@@ -318,11 +317,11 @@ can have its values turned into unary relation types, and the system will valida
 #!test[schema, commit]
 define
 
-relation account-status @abstract, relates subject;
-relation active-status sub account-status;
-relation suspended-status sub account-status;
+relation account_status @abstract, relates subject;
+relation active_status sub account_status;
+relation suspended_status sub account_status;
 
-entity account, plays account-status:subject @card(0..1);
+entity account, plays account_status:subject @card(0..1);
 ----
 
 Note the `@card(0..1)` on the `plays`: the default of `@card(0..)` would allow an account to be active and suspended at the same time, so we tighten it to match the single-valued `status` attribute it replaces.
@@ -332,16 +331,16 @@ Note the `@card(0..1)` on the `plays`: the default of `@card(0..)` would allow a
 #!test[write, commit, count = 1]
 insert
 $account isa account;
-$active isa active-status, links (subject: $account);
+$active isa active_status, links (subject: $account);
 ----
 
-With the enum lifted into the type system, each state can later gain its own attributes and roles (e.g. a `suspended-status` owning a `reason`), and queries over states are type checked like any other pattern:
+With the enum lifted into the type system, each state can later gain its own attributes and roles (e.g. a `suspended_status` owning a `reason`), and queries over states are type checked like any other pattern:
 
 [,typeql]
 ----
 #!test[read, count = 1]
 match
-$status isa account-status, links (subject: $account);  # polymorphic over all states
+$status isa account_status, links (subject: $account);  # polymorphic over all states
 ----
 
 How much type safety you need comes down to a trade-off: the size of the schema you are willing to manage, against the rigor with which your reads and writes are validated.
@@ -351,8 +350,8 @@ More types buy you earlier errors and richer queries; less gets you flexibility.
 
 Role types are defined within the "scope" of a relation type, but are thereafter full-fledged types in their own right: `relation employment, relates employee` creates a role type `employment:employee` that can be queried like any other.
 
-Role types are inherited _as-is_: a `part-time-employment sub employment` inherits the role `employment:employee`.
-There is no distinct role `part-time-employment:employee` — it is the same `employment:employee`, held by `employment` and all of its subtypes.
+Role types are inherited _as-is_: a `part_time_employment sub employment` inherits the role `employment:employee`.
+There is no distinct role `part_time_employment:employee` — it is the same `employment:employee`, held by `employment` and all of its subtypes.
 
 To create a specialized role just for the sub-relation type, create a role subtype with `as`:
 
@@ -361,13 +360,13 @@ To create a specialized role just for the sub-relation type, create a role subty
 #!test[schema, commit]
 define
 
-relation part-time-employment sub employment,
-    relates part-time-employee as employee;
+relation part_time_employment sub employment,
+    relates part_time_employee as employee;
 
-person plays part-time-employment:part-time-employee;
+person plays part_time_employment:part_time_employee;
 ----
 
-This essentially creates a new role type `part-time-employment:part-time-employee sub employment:employee`, and also blocks the inherited `employee` role in `part-time-employment` instances.
+This essentially creates a new role type `part_time_employment:part_time_employee sub employment:employee`, and also blocks the inherited `employee` role in `part_time_employment` instances.
 Note that `plays` declarations are not inherited across the specialization — players of the new role need their own `plays`.
 
 [,typeql]
@@ -377,8 +376,8 @@ match
 $company isa company, has name "TypeDB";
 insert
 $person isa person, has name "Bob";
-$employment isa part-time-employment,
-    links (employer: $company, part-time-employee: $person);
+$employment isa part_time_employment,
+    links (employer: $company, part_time_employee: $person);
 ----
 
 Because of the role subtyping, querying the parent role at read time also resolves players of the specialized role:
@@ -387,10 +386,10 @@ Because of the role subtyping, querying the parent role at read time also resolv
 ----
 #!test[read, count = 2]
 match
-$employment isa employment, links (employee: $x);  # Alice (employee) and Bob (part-time-employee)
+$employment isa employment, links (employee: $x);  # Alice (employee) and Bob (part_time_employee)
 ----
 
-The inherited `employee` role, however, can no longer be used in `part-time-employment` instances — the specialization blocks it:
+The inherited `employee` role, however, can no longer be used in `part_time_employment` instances — the specialization blocks it:
 
 [,typeql]
 ----
@@ -399,8 +398,8 @@ match
 $person isa person, has name "Bob";
 $company isa company, has name "TypeDB";
 insert
-$employment isa part-time-employment,
-    links (employer: $company, employee: $person);  # blocked: use part-time-employee
+$employment isa part_time_employment,
+    links (employer: $company, employee: $person);  # blocked: use part_time_employee
 ----
 
 The cost of a specialized role is that a new name must be created for it.
@@ -430,12 +429,12 @@ For most relations, tighten the default `@card(0..1)` on each `relates` role to 
 #!test[schema, commit]
 define
 
-relation account-holding,
+relation account_holding,
     relates holder @card(1),
     relates account @card(1);
 
-person plays account-holding:holder;
-account plays account-holding:account;
+person plays account_holding:holder;
+account plays account_holding:account;
 ----
 
 A complete account holding commits fine:
@@ -447,7 +446,7 @@ match
 $person isa person, has name "Alice";
 insert
 $account isa account;
-$holding isa account-holding,
+$holding isa account_holding,
     links (holder: $person, account: $account);
 ----
 
@@ -459,30 +458,10 @@ A holding missing its account now fails commit-time validation instead of silent
 match
 $person isa person, has name "Alice";
 insert
-$holding isa account-holding, links (holder: $person);  # no account: rejected at commit
+$holding isa account_holding, links (holder: $person);  # no account: rejected at commit
 ----
 
-The same applies to `owns`: `@card(1)` makes an attribute mandatory, `@card(1..)` requires at least one, and `@key` both requires exactly one and enforces uniqueness:
-
-[,typeql]
-----
-#!test[schema, commit]
-define
-
-attribute subscription-id, value string;
-attribute expiry, value datetime;
-
-entity subscription,
-    owns subscription-id @key,
-    owns expiry @card(1);
-----
-
-[,typeql]
-----
-#!test[write, fail_at = commit]
-insert
-$sub isa subscription, has subscription-id "S-001";  # missing required expiry: rejected
-----
+The same applies to `owns`: `@card(1)` makes an attribute mandatory, `@card(1..)` requires at least one, and `@key` both requires exactly one and enforces uniqueness.
 
 == Constraints
 
@@ -517,7 +496,7 @@ $restaurant isa restaurant, has rating 9;  # out of range for restaurant: reject
 ----
 
 Subtypes can add their own specializations of inherited capabilities, and both the local and the inherited constraints are validated at commit time.
-For example, if an `identity` is required to have at least one `email`, a subtype `service-account` can restrict that to exactly one:
+For example, if an `identity` is required to have at least one `email`, a subtype `service_account` can restrict that to exactly one:
 
 [,typeql]
 ----
@@ -531,7 +510,7 @@ entity identity @abstract,
 
 entity user sub identity;
 
-entity service-account sub identity,
+entity service_account sub identity,
     owns email @card(1);
 ----
 
@@ -547,13 +526,13 @@ $user isa user,
     has email "alice@example.com";
 ----
 
-A `service-account` is checked against both the inherited `@card(1..)` and its local `@card(1)` — so two emails and zero emails are both rejected:
+A `service_account` is checked against both the inherited `@card(1..)` and its local `@card(1)` — so two emails and zero emails are both rejected:
 
 [,typeql]
 ----
 #!test[write, fail_at = commit]
 insert
-$bot isa service-account,
+$bot isa service_account,
     has email "bot@typedb.com",
     has email "bot-backup@typedb.com";  # two emails: violates local @card(1)
 ----
@@ -562,7 +541,7 @@ $bot isa service-account,
 ----
 #!test[write, fail_at = commit]
 insert
-$bot isa service-account;  # no email: violates both the inherited @card(1..) and the local @card(1)
+$bot isa service_account;  # no email: violates both the inherited @card(1..) and the local @card(1)
 ----
 
 Under the hood, `@key` is a composition of xref:{page-version}@typeql-reference::annotations/unique.adoc[`@unique`] and `@card(1)`: `@unique` requires that no two instances of the owner type (including its subtypes) own an attribute of that type with the same value.

--- a/guides/modules/ROOT/partials/nav.adoc
+++ b/guides/modules/ROOT/partials/nav.adoc
@@ -15,4 +15,4 @@
 ** xref:{page-version}@guides::typeql/optimizing-typeql.adoc[]
 ** xref:{page-version}@guides::typeql/sql-vs-typeql.adoc[]
 
-* xref:{page-version}@guides::modeling.adoc[]
+* xref:{page-version}@guides::schema-modeling.adoc[]

--- a/guides/modules/ROOT/partials/nav.adoc
+++ b/guides/modules/ROOT/partials/nav.adoc
@@ -14,3 +14,5 @@
 ** xref:{page-version}@guides::typeql/debugging-typeql.adoc[]
 ** xref:{page-version}@guides::typeql/optimizing-typeql.adoc[]
 ** xref:{page-version}@guides::typeql/sql-vs-typeql.adoc[]
+
+* xref:{page-version}@guides::modeling.adoc[]

--- a/home/modules/ROOT/pages/configure-coding-agent.adoc
+++ b/home/modules/ROOT/pages/configure-coding-agent.adoc
@@ -10,7 +10,7 @@ Set up your AI coding agent so it can write and verify TypeQL on your behalf, in
 Two pieces make vibe querying with TypeDB reliable:
 
 . `typeql-check` - a CLI that statically validates TypeQL syntax, so the agent can self-correct.
-. `typedb-skills/typeql.md` - a skill file that teaches your coding agent the TypeQL language and TypeDB's data model.
+. `typedb-skills` - skill files that teach your coding agent the TypeQL language and TypeDB's data model (`typeql.md`), and how to design good schemas (`modeling.md`).
 
 In our benchmarks, adding both raises Claude's TypeQL pass rate from 23-43% (no tools) to 86-96% - the difference between AI-generated TypeQL being unreliable and being something you can build on.
 
@@ -20,9 +20,12 @@ In our benchmarks, adding both raises Claude's TypeQL pass rate from 23-43% (no 
 See xref:{page-version}@home::install/typeql-check.adoc[] for install instructions across macOS, Linux, and Windows.
 
 [#add_skill]
-== Add the TypeQL skill to your coding agent
+== Add the TypeDB skills to your coding agent
 
-The https://github.com/typedb/typedb-skills[`typedb-skills`,window=_blank] repository contains skill files that teach AI coding agents how to write TypeQL. The relevant file is https://github.com/typedb/typedb-skills/blob/master/typeql.md[`typeql.md`,window=_blank].
+The https://github.com/typedb/typedb-skills[`typedb-skills`,window=_blank] repository contains skill files that teach AI coding agents how to work with TypeDB:
+
+* https://github.com/typedb/typedb-skills/blob/master/typeql.md[`typeql.md`,window=_blank] - the TypeQL language and TypeDB's data model.
+* https://github.com/typedb/typedb-skills/blob/master/modeling.md[`modeling.md`,window=_blank] - schema-modeling guidance: naming, entities vs relations vs attributes, composition, type safety, cardinality, and constraints.
 
 . Clone the repository:
 +
@@ -31,36 +34,36 @@ The https://github.com/typedb/typedb-skills[`typedb-skills`,window=_blank] repos
 git clone https://github.com/typedb/typedb-skills.git
 ----
 
-. Register `typedb-skills/typeql.md` with your coding agent:
+. Register the skill files with your coding agent:
 +
 [tabs]
 ====
 Claude Code::
 +
 --
-Copy `typeql.md` into `~/.claude/skills/typeql.md` (user-level) or `.claude/skills/typeql.md` inside your project (project-level). Claude Code will load it automatically the next time you start a session.
+Copy `typeql.md` and `modeling.md` into `~/.claude/skills/` (user-level) or `.claude/skills/` inside your project (project-level). Claude Code will load them automatically the next time you start a session.
 --
 
 Cursor::
 +
 --
-Copy the contents of `typeql.md` into `.cursor/rules/typeql.mdc` at the root of your project.
+Copy the contents of `typeql.md` into `.cursor/rules/typeql.mdc` and `modeling.md` into `.cursor/rules/modeling.mdc` at the root of your project.
 --
 
 GitHub Copilot::
 +
 --
-Copy the contents of `typeql.md` into `.github/copilot-instructions.md` at the root of your project.
+Append the contents of `typeql.md` and `modeling.md` to `.github/copilot-instructions.md` at the root of your project.
 --
 
 Other agents::
 +
 --
-Most coding agents accept a Markdown rules or instructions file. Point your agent at `typedb-skills/typeql.md` using whatever mechanism it provides for custom instructions.
+Most coding agents accept Markdown rules or instructions files. Point your agent at `typedb-skills/typeql.md` and `typedb-skills/modeling.md` using whatever mechanism it provides for custom instructions.
 --
 ====
 
-With the skill loaded, your coding agent will know TypeQL syntax, the TypeDB data model, and that it can call `typeql-check` to validate the queries it writes.
+With the skills loaded, your coding agent will know TypeQL syntax, the TypeDB data model, schema-modeling best practices, and that it can call `typeql-check` to validate the queries it writes.
 
 == What next?
 


### PR DESCRIPTION
## Goal

We add a new page under `guides/typeql` for schema modeling advice. This captures our current best knowledge and advice on how to model schemas.

## Implementation

- Delete commented out and hanging 'best practices' page
- Add new schema modeling page
- Update agent configuration page to include schema modeling git skill file
