### PR TITLE
Dissolve unused :pageTitle: metadata fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,8 @@ Driver API reference is generated from `typedb-driver` repository partials. To u
 
 ```asciidoc
 = Page Title
-:pageTitle: Page Title
 :description: Brief description for search/SEO (emitted as the page's meta description).
 :keywords: typedb, keyword1, keyword2
 ```
+
+The `=` heading is the page title, used for the browser `<title>` and search result titles.

--- a/core-concepts/modules/ROOT/pages/drivers/analyze.adoc
+++ b/core-concepts/modules/ROOT/pages/drivers/analyze.adoc
@@ -1,5 +1,4 @@
 = Analyzing queries
-:pageTitle: Analyzing queries
 :description: Compiling & analyzing TypeDB queries.
 :keywords: typedb, driver, analyze, type-inference, dry-run, validate
 :test-python: true

--- a/core-concepts/modules/ROOT/pages/drivers/authentication.adoc
+++ b/core-concepts/modules/ROOT/pages/drivers/authentication.adoc
@@ -1,5 +1,4 @@
 = Users & Authentication
-:pageTitle: Authentication
 :description: Understanding authentication with TypeDB drivers.
 :keywords: typedb, driver, authentication, credentials, security
 :test-python: true

--- a/core-concepts/modules/ROOT/pages/drivers/best-practices.adoc
+++ b/core-concepts/modules/ROOT/pages/drivers/best-practices.adoc
@@ -1,5 +1,4 @@
 = Best Practices
-:pageTitle: Best Practices
 :description: Best practices for building robust applications with TypeDB drivers.
 :keywords: typedb, driver, best practices, connection management, error handling, performance, debugging, logging
 

--- a/core-concepts/modules/ROOT/pages/drivers/connections.adoc
+++ b/core-concepts/modules/ROOT/pages/drivers/connections.adoc
@@ -1,5 +1,4 @@
 = Connections
-:pageTitle: Connections
 :description: How to establish and manage connections to TypeDB servers.
 :keywords: typedb, driver, connection, address, port, network
 :test-python: true

--- a/core-concepts/modules/ROOT/pages/drivers/overview.adoc
+++ b/core-concepts/modules/ROOT/pages/drivers/overview.adoc
@@ -1,5 +1,4 @@
 = Overview
-:pageTitle: Overview
 :description: Overview of TypeDB drivers and their conceptual model.
 :keywords: typedb, driver, api, RPC, HTTP, architecture
 :test-python: true

--- a/core-concepts/modules/ROOT/pages/drivers/queries.adoc
+++ b/core-concepts/modules/ROOT/pages/drivers/queries.adoc
@@ -1,5 +1,4 @@
 = Queries
-:pageTitle: Queries
 :description: Executing TypeQL queries and processing results with TypeDB drivers.
 :keywords: typedb, driver, queries, typeql, results, concept rows, documents
 :test-python: true

--- a/core-concepts/modules/ROOT/pages/drivers/transactions.adoc
+++ b/core-concepts/modules/ROOT/pages/drivers/transactions.adoc
@@ -1,5 +1,4 @@
 = Transactions
-:pageTitle: Transactions
 :description: Understanding transaction types, lifecycle, and patterns with TypeDB drivers.
 :keywords: typedb, driver, transactions, isolation, concurrency
 :test-python: true

--- a/guides/modules/ROOT/pages/integrations/deploy-through-api.adoc
+++ b/guides/modules/ROOT/pages/integrations/deploy-through-api.adoc
@@ -1,6 +1,5 @@
 = Deploy TypeDB via the Cloud API
 :keywords: typedb, typeql, tutorial, guide, api, cloud, cluster, deploy
-:pageTitle: Deploy TypeDB via the Cloud API
 :description: A guide on deploying TypeDB through the API
 :page-toclevels: 2
 :tabs-sync-option:

--- a/guides/modules/ROOT/pages/integrations/langgraph.adoc
+++ b/guides/modules/ROOT/pages/integrations/langgraph.adoc
@@ -1,6 +1,5 @@
 = AI Agents persistence with LangGraph and TypeDB
 :keywords: typedb, typeql, tutorial, guide, langgraph, ai, agents, llm, checkpoint, memory
-:pageTitle: AI Agents persistence with LangGraph and TypeDB
 :description: Use the TypeDB plugin for LangGraph to persist agent state and long-term memory.
 :page-toclevels: 2
 

--- a/guides/modules/ROOT/pages/integrations/social-network.adoc
+++ b/guides/modules/ROOT/pages/integrations/social-network.adoc
@@ -1,7 +1,6 @@
 = Full Stack Application - Social Network
 :page-aliases: {page-version}@examples::social-network.adoc
 :keywords: typedb, typeql, tutorial, rust, java, python, quickstart, start, sample, example, application, app
-:pageTitle: Application example
 :description: A simple example application in multiple languages.
 :tabs-sync-option:
 :page-toclevels: 2

--- a/guides/modules/ROOT/pages/integrations/use-github-actions.adoc
+++ b/guides/modules/ROOT/pages/integrations/use-github-actions.adoc
@@ -1,6 +1,5 @@
 = Use TypeDB in GitHub Actions
 :keywords: typedb, typeql, tutorial, guide, github actions, ci
-:pageTitle: Use TypeDB in GitHub Actions
 :description: A guide on using the TypeDB in GitHub Actions
 :page-toclevels: 2
 

--- a/guides/modules/ROOT/pages/schema-modeling.adoc
+++ b/guides/modules/ROOT/pages/schema-modeling.adoc
@@ -1,6 +1,5 @@
 = Schema modeling
 :keywords: typedb, typeql, modeling, schema, entities, relations, attributes, naming, composition, type safety, cardinality, constraints, functions, guide
-:pageTitle: Schema modeling
 :description: Design TypeDB schemas - entities vs relations vs attributes, naming, composition, type safety, cardinality, value, and role constraints, and functions.
 :page-toclevels: 2
 :sectnums:

--- a/guides/modules/ROOT/pages/typeql/advanced-pipelines.adoc
+++ b/guides/modules/ROOT/pages/typeql/advanced-pipelines.adoc
@@ -1,6 +1,5 @@
 = Advanced query pipelines
 :keywords: typedb, typeql, tutorial, guide, console
-:pageTitle: 
 :description: 
 :page-toclevels: 2
 :tabs-sync-option:

--- a/guides/modules/ROOT/pages/typeql/debugging-typeql.adoc
+++ b/guides/modules/ROOT/pages/typeql/debugging-typeql.adoc
@@ -1,6 +1,5 @@
 = Debugging TypeQL
 :keywords: typedb, typeql, debugging, guide, studio
-:pageTitle: Debugging TypeQL queries
 :description: Learn how to leverage TypeQL's composability to quickly debug queries and pipelines.
 :page-toclevels: 2
 :page-aliases: {page-version}@maintenance-operation::troubleshooting/debugging-queries.adoc

--- a/guides/modules/ROOT/pages/typeql/insert-update-data.adoc
+++ b/guides/modules/ROOT/pages/typeql/insert-update-data.adoc
@@ -1,6 +1,5 @@
 = Inserting and updating data
 :keywords: typedb, typeql, tutorial, guide, console, crud
-:pageTitle: 
 :description: 
 :page-toclevels: 2
 :tabs-sync-option:

--- a/guides/modules/ROOT/pages/typeql/optimizing-typeql.adoc
+++ b/guides/modules/ROOT/pages/typeql/optimizing-typeql.adoc
@@ -1,6 +1,5 @@
 = Optimizing TypeQL
 :keywords: typedb, typeql, optimization, performance, guide
-:pageTitle: Optimizing TypeQL queries
 :description: Learn how TypeDB's optimizer works and how to write efficient TypeQL queries.
 :page-toclevels: 2
 :page-aliases: {page-version}@maintenance-operation::troubleshooting/optimizing-queries.adoc

--- a/guides/modules/ROOT/pages/typeql/read-data.adoc
+++ b/guides/modules/ROOT/pages/typeql/read-data.adoc
@@ -1,6 +1,5 @@
 = Reading data
 :keywords: typedb, typeql, tutorial, guide, console
-:pageTitle: 
 :description: 
 :page-toclevels: 2
 :tabs-sync-option:

--- a/home/modules/ROOT/pages/configure-coding-agent.adoc
+++ b/home/modules/ROOT/pages/configure-coding-agent.adoc
@@ -1,7 +1,6 @@
 = Configure coding agent
 :page-aliases: {page-version}@home::get-started/configure-coding-agent.adoc
 :keywords: start, learn, typedb, typeql, tutorial, quickstart, vibe, coding, ai, agent, claude, cursor, copilot, typeql-check, skills
-:pageTitle: Configure coding agent
 :description: Configure your AI coding agent to write valid TypeQL
 :tabs-sync-option:
 

--- a/learn-typedb/modules/ROOT/pages/index.adoc
+++ b/learn-typedb/modules/ROOT/pages/index.adoc
@@ -1,5 +1,4 @@
 = Learn TypeDB
-:pageTitle: Learn TypeDB
 :description: Learn TypeDB and TypeQL through hands-on guides and courses.
 :keywords: typedb, typeql, learn, tutorial, quickstart, crash course, rbac, course
 :page-aliases: {page-version}@home::crash-course.adoc, {page-version}@home::crash-course/overview.adoc, {page-version}@home::crash-course/get-started.adoc

--- a/learn-typedb/modules/ROOT/pages/quickstart/data.adoc
+++ b/learn-typedb/modules/ROOT/pages/quickstart/data.adoc
@@ -1,6 +1,5 @@
 = Create data
 :page-aliases: {page-version}@home::get-started/data.adoc
-:pageTitle: Create data
 :keywords: start, learn, typedb, typeql, tutorial, quickstart, console, studio, database, create, insert, query, schema
 :description: Use queries to load data into your database
 :tabs-sync-option:

--- a/learn-typedb/modules/ROOT/pages/quickstart/index.adoc
+++ b/learn-typedb/modules/ROOT/pages/quickstart/index.adoc
@@ -1,5 +1,4 @@
 = Quickstart: Basics
-:pageTitle: Quickstart: Basics
 :description: Get started with TypeDB and TypeQL
 :keywords: start, learn, typedb, typeql, cloud, tutorial, quickstart, get-started, console, studio, database, create, insert, query
 :page-aliases: {page-version}@home::quickstart.adoc, {page-version}@home::get-started/index.adoc

--- a/learn-typedb/modules/ROOT/pages/quickstart/overview.adoc
+++ b/learn-typedb/modules/ROOT/pages/quickstart/overview.adoc
@@ -1,6 +1,5 @@
 = Overview
 :page-aliases: {page-version}@home::get-started/overview.adoc
-:pageTitle: Overview
 :description: Overview of the Quickstart guide
 :keywords: start, learn, typedb, typeql, cloud, tutorial, quickstart, get-started, console, studio, database, create, insert, query, overview
 :test-typeql: linear

--- a/learn-typedb/modules/ROOT/pages/quickstart/schema.adoc
+++ b/learn-typedb/modules/ROOT/pages/quickstart/schema.adoc
@@ -1,7 +1,6 @@
 = Create a schema
 :page-aliases: {page-version}@home::get-started/schema.adoc
 :keywords: start, learn, typedb, typeql, tutorial, quickstart, console, studio, database, create, insert, query, schema
-:pageTitle: Create a schema
 :description: Create a database and initialize the schema
 :tabs-sync-option:
 :test-typeql: linear

--- a/learn-typedb/modules/ROOT/pages/quickstart/setup.adoc
+++ b/learn-typedb/modules/ROOT/pages/quickstart/setup.adoc
@@ -1,7 +1,6 @@
 = Setup
 :page-aliases: {page-version}@home::get-started/setup.adoc
 :keywords: start, learn, typedb, typeql, cloud, tutorial, quickstart, get-started, console, studio, database, create, insert, query, setup
-:pageTitle: Setup
 :description: Start running TypeDB and open TypeDB Studio
 :tabs-sync-option:
 

--- a/learn-typedb/modules/ROOT/pages/rbac-in-business/00-get-started-studio.adoc
+++ b/learn-typedb/modules/ROOT/pages/rbac-in-business/00-get-started-studio.adoc
@@ -1,5 +1,4 @@
 = Chapter Zero: Get Started in TypeDB Studio
-:pageTitle: Chapter Zero: Get Started in TypeDB Studio
 :description: Setting up your environment before your first query.
 :keywords: typedb, typeql, rbac, studio, database, transaction, auto mode, getting started
 

--- a/learn-typedb/modules/ROOT/pages/rbac-in-business/01-identity-registry.adoc
+++ b/learn-typedb/modules/ROOT/pages/rbac-in-business/01-identity-registry.adoc
@@ -1,5 +1,4 @@
 = Chapter One: The Identity Registry
-:pageTitle: Chapter One: The Identity Registry
 :description: Entities, attributes, and your first schema.
 :keywords: typedb, typeql, rbac, entity, attribute, define, key, abstract, schema
 

--- a/learn-typedb/modules/ROOT/pages/rbac-in-business/02-identity-model.adoc
+++ b/learn-typedb/modules/ROOT/pages/rbac-in-business/02-identity-model.adoc
@@ -1,5 +1,4 @@
 = Chapter Two: The Identity Management System
-:pageTitle: Chapter Two: The Identity Management System
 :description: Type hierarchies, relations, and the org structure.
 :keywords: typedb, typeql, rbac, type hierarchy, inheritance, relation, role, cardinality, abstract
 

--- a/learn-typedb/modules/ROOT/pages/rbac-in-business/03-populating-amasoft.adoc
+++ b/learn-typedb/modules/ROOT/pages/rbac-in-business/03-populating-amasoft.adoc
@@ -1,5 +1,4 @@
 = Chapter Three: Populating Amasoft
-:pageTitle: Chapter Three: Populating Amasoft
 :description: Insert, match, and fetch - the pattern language.
 :keywords: typedb, typeql, rbac, insert, match, fetch, delete, pattern, sub, polymorphism
 

--- a/learn-typedb/modules/ROOT/pages/rbac-in-business/04-granting-access.adoc
+++ b/learn-typedb/modules/ROOT/pages/rbac-in-business/04-granting-access.adoc
@@ -1,5 +1,4 @@
 = Chapter Four: Granting Access
-:pageTitle: Chapter Four: Granting Access
 :description: The access model, @values, and permission queries.
 :keywords: typedb, typeql, rbac, access grant, permission, values, n-ary relation, card
 

--- a/learn-typedb/modules/ROOT/pages/rbac-in-business/05-levels-and-promotions.adoc
+++ b/learn-typedb/modules/ROOT/pages/rbac-in-business/05-levels-and-promotions.adoc
@@ -1,5 +1,4 @@
 = Chapter Five: Levels & Promotions
-:pageTitle: Chapter Five: Levels & Promotions
 :description: Level assignment and two organisational changes.
 :keywords: typedb, typeql, rbac, level, promotion, links, range, history
 

--- a/learn-typedb/modules/ROOT/pages/rbac-in-business/06-access-audit.adoc
+++ b/learn-typedb/modules/ROOT/pages/rbac-in-business/06-access-audit.adoc
@@ -1,5 +1,4 @@
 = Chapter Six: The Access Audit
-:pageTitle: Chapter Six: The Access Audit
 :description: Operators, pipelines, aggregation, and compliance queries.
 :keywords: typedb, typeql, rbac, audit, aggregation, reduce, sort, limit, disjunction, compliance
 

--- a/learn-typedb/modules/ROOT/pages/rbac-in-business/07-policies-as-functions.adoc
+++ b/learn-typedb/modules/ROOT/pages/rbac-in-business/07-policies-as-functions.adoc
@@ -1,5 +1,4 @@
 = Chapter Seven: Access Policies as Functions
-:pageTitle: Chapter Seven: Access Policies as Functions
 :description: Enshrining Amasoft's policies in reusable code
 :keywords: typedb, typeql, rbac, function, fun, let, policy, composition, separation of duties, disjunction
 

--- a/learn-typedb/modules/ROOT/pages/rbac-in-business/08-accountable-access.adoc
+++ b/learn-typedb/modules/ROOT/pages/rbac-in-business/08-accountable-access.adoc
@@ -1,5 +1,4 @@
 = Chapter Eight: Accountable Access
-:pageTitle: Chapter Eight: Accountable Access
 :description: Policy grants, exceptions, and access reviews - why every grant exists.
 :keywords: typedb, typeql, rbac, policy, exception, access review, sub-relation, migration, abstract, accountability
 

--- a/learn-typedb/modules/ROOT/pages/rbac-in-business/09-production-rbac.adoc
+++ b/learn-typedb/modules/ROOT/pages/rbac-in-business/09-production-rbac.adoc
@@ -1,5 +1,4 @@
 = Chapter Nine: Production RBAC
-:pageTitle: Chapter Nine: Production RBAC
 :description: Transactions, drivers, schema migrations, and idempotent pipelines.
 :keywords: typedb, typeql, rbac, transaction, put, update, schema migration, idempotent, provisioning, access check, deprovision, kill switch
 

--- a/learn-typedb/modules/ROOT/pages/rbac-in-business/10-epilogue.adoc
+++ b/learn-typedb/modules/ROOT/pages/rbac-in-business/10-epilogue.adoc
@@ -1,5 +1,4 @@
 = Epilogue: You Are the Architect
-:pageTitle: Epilogue: You Are the Architect
 :description: You have completed RBAC In Business - and built a production-grade foundation.
 :keywords: typedb, typeql, rbac, epilogue, summary, architect
 :figure-caption!:

--- a/learn-typedb/modules/ROOT/pages/rbac-in-business/index.adoc
+++ b/learn-typedb/modules/ROOT/pages/rbac-in-business/index.adoc
@@ -1,5 +1,4 @@
 = Crash course: RBAC In Business
-:pageTitle: Crash course: RBAC In Business
 :description: Build Amasoft's role-based access control system in TypeDB - a professional learning journey from analyst to architect.
 :keywords: typedb, typeql, rbac, identity, access control, crash course, tutorial, schema, functions, audit
 

--- a/maintenance-operation/modules/ROOT/pages/diagnostics-endpoint.adoc
+++ b/maintenance-operation/modules/ROOT/pages/diagnostics-endpoint.adoc
@@ -1,6 +1,5 @@
 = Diagnostics monitoring endpoint
 :keywords: typedb, diagnostics, monitoring, prometheus, metrics, observability
-:pageTitle: Diagnostics monitoring endpoint
 :description: HTTP endpoint for scraping TypeDB server metrics in Prometheus or JSON format.
 
 TypeDB exposes a diagnostics HTTP endpoint that serves server and per-database metrics in Prometheus text format or JSON.

--- a/maintenance-operation/modules/ROOT/pages/typedb-configuration.adoc
+++ b/maintenance-operation/modules/ROOT/pages/typedb-configuration.adoc
@@ -1,6 +1,5 @@
 = TypeDB Configuration
 :keywords: typedb, config, CLI
-:pageTitle: Server configuration manual
 :description: TypeDB Server configuration.
 
 You can configure a TypeDB server via two means: a YAML config file or command line options.

--- a/reference/modules/ROOT/pages/typedb-cluster/console.adoc
+++ b/reference/modules/ROOT/pages/typedb-cluster/console.adoc
@@ -1,5 +1,4 @@
 = Console in clustered TypeDB
-:pageTitle: Console in clustered TypeDB
 :description: Cluster-specific features in TypeDB Console: multi-replica connections, server routing, and cluster inspection.
 :keywords: typedb, cluster, console, replication, failover, server routing, replicas, primary, secondary
 :test-python: false

--- a/reference/modules/ROOT/pages/typedb-cluster/drivers.adoc
+++ b/reference/modules/ROOT/pages/typedb-cluster/drivers.adoc
@@ -1,5 +1,4 @@
 = Drivers in clustered TypeDB
-:pageTitle: Drivers in clustered TypeDB
 :description: Cluster-specific features in TypeDB drivers: multi-replica connections, failover, and server routing.
 :keywords: typedb, cluster, driver, replication, failover, server routing, replicas, primary, secondary
 :test-python: false

--- a/reference/modules/ROOT/pages/typedb-grpc-drivers/c.adoc
+++ b/reference/modules/ROOT/pages/typedb-grpc-drivers/c.adoc
@@ -1,5 +1,4 @@
 = C gRPC driver
-:pageTitle: C gRPC driver
 :description: API Reference of TypeDB gRPC driver for C.
 :keywords: typedb, client, driver, c, grpc, api, reference
 :page-toclevels: 2

--- a/reference/modules/ROOT/pages/typedb-grpc-drivers/csharp.adoc
+++ b/reference/modules/ROOT/pages/typedb-grpc-drivers/csharp.adoc
@@ -1,5 +1,4 @@
 = C# gRPC driver
-:pageTitle: C# gRPC driver
 :description: API Reference of TypeDB gRPC driver for C#.
 :keywords: typedb, client, driver, csharp, grpc, api, reference
 :page-toclevels: 2

--- a/reference/modules/ROOT/pages/typedb-grpc-drivers/java.adoc
+++ b/reference/modules/ROOT/pages/typedb-grpc-drivers/java.adoc
@@ -1,5 +1,4 @@
 = Java gRPC driver
-:pageTitle: Java gRPC driver
 :description: API Reference of TypeDB gRPC driver for Java.
 :keywords: typedb, client, driver, java, grpc, api, refernce
 :page-toclevels: 2

--- a/reference/modules/ROOT/pages/typedb-grpc-drivers/python.adoc
+++ b/reference/modules/ROOT/pages/typedb-grpc-drivers/python.adoc
@@ -1,5 +1,4 @@
 = Python gRPC driver
-:pageTitle: Python gRPC driver
 :description: API Reference of TypeDB gRPC driver for Python.
 :keywords: typedb, client, driver, python, grpc, api, refernce
 :page-toclevels: 2

--- a/reference/modules/ROOT/pages/typedb-grpc-drivers/rust.adoc
+++ b/reference/modules/ROOT/pages/typedb-grpc-drivers/rust.adoc
@@ -1,5 +1,4 @@
 = Rust gRPC driver
-:pageTitle: Rust gRPC driver
 :description: API Reference of TypeDB gRPC driver for Rust.
 :keywords: typedb, client, driver, rust, grpc, api, refernce
 :page-toclevels: 2

--- a/reference/modules/ROOT/pages/typedb-http-drivers/typescript.adoc
+++ b/reference/modules/ROOT/pages/typedb-http-drivers/typescript.adoc
@@ -1,7 +1,6 @@
 = Typescript HTTP Driver
 :description: API Reference of TypeDB HTTP driver for Typescript.
 :keywords: typedb, client, driver, typescript, http, api, refernce
-:pageTitle: Typescript HTTP driver API reference
 :page-toclevels: 2
 :page-aliases: {page-version}@drivers::nodejs/api-reference.adoc, {page-version}@reference::http-drivers/typescript.adoc
 

--- a/tools/modules/ROOT/pages/admin.adoc
+++ b/tools/modules/ROOT/pages/admin.adoc
@@ -1,6 +1,5 @@
 = TypeDB Admin Tool
 :keywords: typedb, admin, cli, server, status, version, users, reset-password
-:pageTitle: TypeDB Admin Tool
 :description: Local CLI for inspecting and managing a running TypeDB server.
 
 `typedb admin` is a CLI tool bundled with every TypeDB distribution.

--- a/tools/modules/ROOT/pages/loader/json-example.adoc
+++ b/tools/modules/ROOT/pages/loader/json-example.adoc
@@ -1,6 +1,5 @@
 = JSON to TypeDB
 :keywords: typedb, typeql, tutorial, guide, loader
-:pageTitle:
 :description:
 :page-toclevels: 2
 :tabs-sync-option:

--- a/tools/modules/ROOT/pages/loader/quickstart.adoc
+++ b/tools/modules/ROOT/pages/loader/quickstart.adoc
@@ -1,6 +1,5 @@
 = Quickstart
 :keywords: typedb, typeql, tutorial, guide, loader
-:pageTitle:
 :description:
 :page-toclevels: 2
 :tabs-sync-option:

--- a/tools/modules/ROOT/pages/loader/reference.adoc
+++ b/tools/modules/ROOT/pages/loader/reference.adoc
@@ -1,6 +1,5 @@
 = TypeDB Loader Reference
 :keywords: typedb, loader
-:pageTitle:
 :description:
 :page-toclevels: 2
 :tabs-sync-option:

--- a/tools/modules/ROOT/pages/loader/sql-example.adoc
+++ b/tools/modules/ROOT/pages/loader/sql-example.adoc
@@ -1,6 +1,5 @@
 = Migrating a SQL Database
 :keywords: typedb, typeql, tutorial, guide, loader
-:pageTitle:
 :description:
 :page-toclevels: 2
 :tabs-sync-option:

--- a/tools/modules/ROOT/pages/typeql-check.adoc
+++ b/tools/modules/ROOT/pages/typeql-check.adoc
@@ -1,6 +1,5 @@
 = TypeQL Syntax Checker
 :keywords: typedb, typeql, syntax, check, lint, cli
-:pageTitle: TypeQL Syntax Checker
 :description: CLI tool for validating TypeQL query syntax.
 
 `typeql-check` is a small CLI tool that validates the syntax of a TypeQL query without sending it to a TypeDB server.


### PR DESCRIPTION
## Goal

We dissolve the unused :pageTitle: metadata field that was present on 52 pages. This means less code to maintain. Dead code is never anything but noise.

## Implementation

Delete all :pageTitle: metadata fields. Delete the instruction in CLAUDE.md that advises Claude to use it.