### PR TITLE
Document type renaming via redefine label

### DIFF
--- a/dependencies/typedb/artifacts.bzl
+++ b/dependencies/typedb/artifacts.bzl
@@ -25,5 +25,5 @@ def typedb_artifact():
         artifact_name = "typedb-all-{platform}-{version}.{ext}",
         tag_source = deployment["artifact"]["release"]["download"],
         commit_source = deployment["artifact"]["snapshot"]["download"],
-        commit = "2436a06d2589aa225c687a950ffeffd6ee41e5f8",
+        tag = "3.12.3",
     )

--- a/reference/modules/ROOT/pages/typedb-2-vs-3/diff.adoc
+++ b/reference/modules/ROOT/pages/typedb-2-vs-3/diff.adoc
@@ -47,7 +47,7 @@ Visit the xref:{page-version}@reference::index.adoc[Reference] to access their f
 
 - Now, all schema and data fetching and modifications are performed through a single `transaction.query("your query")` interface.
 - No more `query().insert()` and `query().define()`.
-- No more `concept.delete()`, `concept.getHas()`, or `type.setLabel()`: types are renamed with a xref:{page-version}@typeql-reference::schema/redefine.adoc[`redefine` query] (`redefine person label user;`).
+- No more `concept.delete()`, `concept.getHas()`, or `type.setLabel()`: these are expected to be executed via TypeQL queries.
 - Concept structure is preserved (the only difference: `Thing` is renamed to `Instance`), casts are available, and it is possible to retrieve something simple as a type's label or an attribute's value, that are sent with the type itself.
 - In OOP languages (like Java and Python), concepts have `try` versions of their methods, available for any concept and returning optional results.
 Using casting, the concrete methods returning results directly become available, as in 2.x.

--- a/reference/modules/ROOT/pages/typedb-2-vs-3/diff.adoc
+++ b/reference/modules/ROOT/pages/typedb-2-vs-3/diff.adoc
@@ -47,7 +47,7 @@ Visit the xref:{page-version}@reference::index.adoc[Reference] to access their f
 
 - Now, all schema and data fetching and modifications are performed through a single `transaction.query("your query")` interface.
 - No more `query().insert()` and `query().define()`.
-- No more `concept.delete()` or `concept.getHas()`.
+- No more `concept.delete()`, `concept.getHas()`, or `type.setLabel()`: types are renamed with a xref:{page-version}@typeql-reference::schema/redefine.adoc[`redefine` query] (`redefine person label user;`).
 - Concept structure is preserved (the only difference: `Thing` is renamed to `Instance`), casts are available, and it is possible to retrieve something simple as a type's label or an attribute's value, that are sent with the type itself.
 - In OOP languages (like Java and Python), concepts have `try` versions of their methods, available for any concept and returning optional results.
 Using casting, the concrete methods returning results directly become available, as in 2.x.

--- a/typeql-reference/modules/ROOT/pages/keywords.adoc
+++ b/typeql-reference/modules/ROOT/pages/keywords.adoc
@@ -143,7 +143,7 @@ Constructs a xref:{page-version}@typeql-reference::statements/comparisons.adoc#_
 === Identity statements
 
 `label`::
-Constructs a xref:{page-version}@typeql-reference::statements/label.adoc[], used to identify a type by its label.
+Constructs a xref:{page-version}@typeql-reference::statements/label.adoc[], used to identify a type by its label, or to rename a type in a xref:{page-version}@typeql-reference::schema/redefine.adoc[].
 
 `iid`::
 Constructs an xref:{page-version}@typeql-reference::statements/iid.adoc[], used to identify a data instance by its internal ID.

--- a/typeql-reference/modules/ROOT/pages/schema/redefine.adoc
+++ b/typeql-reference/modules/ROOT/pages/schema/redefine.adoc
@@ -3,12 +3,12 @@
 
 Redefine queries are used
 // tag::overview[]
-to modify existing types, capabilities, annotations, or functions in the schema.
+to modify existing types, capabilities, annotations, or functions in the schema, or to rename types.
 // end::overview[]
 
 == Syntax
 
-Redefine queries start with the `redefine` keyword following by a single xref:{page-version}@typeql-reference::schema/define.adoc[definition statement] of the define queries format.
+Redefine queries start with the `redefine` keyword following by a single xref:{page-version}@typeql-reference::schema/define.adoc[definition statement] of the define queries format, or a single type renaming statement.
 
 [,typeql]
 ----
@@ -16,11 +16,26 @@ redefine
   <definition_statement>
 ----
 
+.Type renaming statement
+[,typeql]
+----
+[<kind>] <label> label <new label>;
+----
+
+.Role type renaming statement
+[,typeql]
+----
+<relation label>:<role label> label <new role label>;
+----
+
 == Behavior
 
-Redefine queries can be used to modify types and type capabilities or to override functions.
+Redefine queries can be used to modify types and type capabilities, to rename types, or to override functions.
 
 For clarity and precision, only one redefinition is allowed per query.
+
+Renaming a type changes only its label: its data, capabilities, annotations, and position in the type hierarchy are preserved.
+Functions are not updated to the new label, so if a stored function refers to a renamed type by its old label, the commit fails.
 
 An error is returned (on execution or on commit), and no changes are preserved, if:
 
@@ -28,10 +43,12 @@ An error is returned (on execution or on commit), and no changes are preserved, 
 - The redefinition matches the definition and does nothing.
 - There are multiple changes in the schema in the result of the redefinition.
 - The query results in an invalid schema.
+- The new label of a renamed type is already in use (for role types, within the same relation type hierarchy).
 
 [#_statements_behavior]
 === Statements
 
+* xref:{page-version}@typeql-reference::statements/label.adoc[`label` statements] rename entity, relation, attribute, and role types.
 * xref:{page-version}@typeql-reference::statements/relates.adoc[`relates` statements] redefine role types specialization using `relates ... as`.
 * xref:{page-version}@typeql-reference::statements/value.adoc[`value` statements] redefine value types of attribute types.
 * xref:{page-version}@typeql-reference::statements/sub.adoc[`sub` statements] redefine supertypes of types.
@@ -89,6 +106,29 @@ redefine post owns tag @card(0..5);
 ----
 #!test[schema]
 redefine fathership relates father as parent;
+----
+
+=== Renaming types
+
+.Renaming an entity type
+[,typeql]
+----
+#!test[schema]
+redefine entity post label article;
+----
+
+.Renaming an attribute type without specifying its kind
+[,typeql]
+----
+#!test[schema]
+redefine tag label hashtag;
+----
+
+.Renaming a role type
+[,typeql]
+----
+#!test[schema]
+redefine parentship:child label offspring;
 ----
 
 === Redefining functions

--- a/typeql-reference/modules/ROOT/pages/statements/label.adoc
+++ b/typeql-reference/modules/ROOT/pages/statements/label.adoc
@@ -4,9 +4,11 @@
 
 The constraint `$t label <LABEL>` matches all types `$t` that have the label (name) `<LABEL>`.
 
+In a xref:{page-version}@typeql-reference::schema/redefine.adoc[redefine query], the statement `<LABEL> label <NEW LABEL>` renames the type `<LABEL>` to `<NEW LABEL>`.
+
 == Defining type labels
 
-The `label` keyword is only used when matching on a type label. The type label is created automatically when the type is defined.
+The `label` keyword is not used when defining types. The type label is created automatically when the type is defined.
 
 [,typeql]
 ----
@@ -20,4 +22,27 @@ define entity user;
 ----
 #!test[schema]
 match $t label user;
+----
+
+== Redefining type labels
+
+The `label` keyword can be used in a redefine query to rename an existing type.
+The kind of the type can optionally be specified.
+
+[,typeql]
+----
+#!test[schema]
+redefine entity user label member;
+----
+
+Role types are renamed using their scoped label.
+
+[,typeql]
+----
+#!test[schema]
+#{{
+define relation friendship relates friend;
+#}}
+#!test[schema]
+redefine friendship:friend label participant;
 ----


### PR DESCRIPTION
## Goal

Documents renaming entity, relation, attribute and role types with 'redefine <type> label <new label>' in the TypeQL reference, and bumps the docs test server to 3.12.3 so the new examples run in CI.
