### PR TITLE
Additional examples and search fixes

### DIFF
--- a/academy/modules/ROOT/pages/7-understanding-query-patterns/7.5-value-expressions.adoc
+++ b/academy/modules/ROOT/pages/7-understanding-query-patterns/7.5-value-expressions.adoc
@@ -85,17 +85,3 @@ We will explore the different value operations, along with the value types they 
 == Arithmetic operations
 
 TypeQL ships with a number of built-in operators and functions. See the xref:{page-version}@typeql-reference::expressions/index.adoc[expressions reference] for the current list.
-
-== String concatenation
-
-Applied to two strings, `+` *concatenates* them:
-
-[,typeql]
-----
-match
-$book isa book, has title $title, has isbn-13 $isbn;
-let $label = $title + " (ISBN " + $isbn + ")";
-fetch { "label": $label };
-----
-
-Both operands must be strings.

--- a/academy/modules/ROOT/pages/7-understanding-query-patterns/7.5-value-expressions.adoc
+++ b/academy/modules/ROOT/pages/7-understanding-query-patterns/7.5-value-expressions.adoc
@@ -85,3 +85,17 @@ We will explore the different value operations, along with the value types they 
 == Arithmetic operations
 
 TypeQL ships with a number of built-in operators and functions. See the xref:{page-version}@typeql-reference::expressions/index.adoc[expressions reference] for the current list.
+
+== String concatenation
+
+Applied to two strings, `+` *concatenates* them:
+
+[,typeql]
+----
+match
+$book isa book, has title $title, has isbn-13 $isbn;
+let $label = $title + " (ISBN " + $isbn + ")";
+fetch { "label": $label };
+----
+
+Both operands must be strings.

--- a/academy/modules/ROOT/pages/7-understanding-query-patterns/summary.adoc
+++ b/academy/modules/ROOT/pages/7-understanding-query-patterns/summary.adoc
@@ -102,6 +102,7 @@ $string like "^regex pattern$";
 * The *assignment operator* `let $var = <expression>` is used to specify the value of a computed variable.
 * The *assignment iterator* `let $var in <expression>` is used to specify the value of a of iterating over a computed iterable, one at a time
 * Numeric values can be computed using *arithmetic operators* `^`, `+*+`, `/`, `%`, `+`, and `-`, as well as *arithmetic functions* `min`, `max`, `round`, `floor`, `ceil`, and `abs` inside expressions
+* String values can be *concatenated* using the `+` operator, for example `let $label = $title + " (" + $isbn + ")"`
 
 == xref:{page-version}@academy::7-understanding-query-patterns/7.6-solution-set-semantics.adoc[Solution set semantics]
 

--- a/academy/modules/ROOT/pages/8-composing-clauses/8.2-aggregations.adoc
+++ b/academy/modules/ROOT/pages/8-composing-clauses/8.2-aggregations.adoc
@@ -95,3 +95,22 @@ let $line_total = $quantity * $retail_price;
 reduce $order_total = sum($line_total) groupby $id;
 fetch { "id": $id, "order-total": $order_total };
 ----
+
+== Filtering aggregated results
+
+A `reduce` can be followed by another `match`, for instance to filter groups by their aggregated value:
+
+[,typeql]
+----
+match
+$book isa book;
+$review isa review, has score $score;
+rating ($review, $book);
+reduce $avg_score = mean($score) groupby $book;
+match
+$avg_score >= 8.0;
+$book has title $title;
+fetch { "title": $title, "average-score": $avg_score };
+----
+
+Only the grouping variables and aggregated values are available after a `reduce`, so `$review` and `$score` cannot be used in the second `match`.

--- a/academy/modules/ROOT/pages/8-composing-clauses/summary.adoc
+++ b/academy/modules/ROOT/pages/8-composing-clauses/summary.adoc
@@ -23,6 +23,7 @@ limit N;
 
 * Use `reduce` operators to aggregate streams
 * The reduce operators are `count`, `sum`, `max`, `min`, `mean`, `median`, and `std`. Except for `count`, each modifier takes a variable to aggregate over as an argument, which can represent either a numeric attribute or a numeric value.
+* A `match` after a `reduce` filters groups by their aggregated value; only grouping variables and aggregated values are available after a `reduce`.
 * You can group reductions by using `groupby`
 +
 [,typeql]

--- a/core-concepts/modules/ROOT/pages/typeql/queries-as-functions.adoc
+++ b/core-concepts/modules/ROOT/pages/typeql/queries-as-functions.adoc
@@ -1,5 +1,6 @@
 = Queries as Functions
 :test-typeql: linear
+:keywords: function, functions
 
 TypeQL function provides a way to create abstractions over existing data,
 allowing queries to be expressed at a higher level.

--- a/core-concepts/modules/ROOT/pages/typeql/queries-as-functions.adoc
+++ b/core-concepts/modules/ROOT/pages/typeql/queries-as-functions.adoc
@@ -74,6 +74,35 @@ return count($posting);
 `reduce` returns a single answer, since it aggregates all answers into one.
 ====
 
+== Preamble functions
+A query can also declare its own functions in a *preamble*, with one `with` clause per function.
+Preamble functions may call each other as well as schema functions.
+
+[,typeql]
+.Find people with a friend-of-a-friend who is better connected than they are
+----
+#!test[read]
+with fun friend_count($p: person) -> integer:
+match
+    $f isa friendship, links (friend: $p, friend: $other);
+return count;
+
+with fun friends_of_friends($p: person) -> { person }:
+match
+    $f1 isa friendship, links (friend: $p, friend: $mid);
+    $f2 isa friendship, links (friend: $mid, friend: $fof);
+    not { $fof is $p; };
+return { $fof };
+
+match
+    $p isa person;
+    let $fof in friends_of_friends($p);
+    friend_count($fof) > friend_count($p);
+select $p, $fof;
+----
+
+See xref:{page-version}@typeql-reference::pipelines/with.adoc[Preamble] in the TypeQL reference for details.
+
 == Cyclic functions & tabling
 TypeDB tables recursive functions to break cycles. This has implications on the best way to implement the recursion.
 The classic example is computing the transitive closure of a function.
@@ -99,7 +128,7 @@ match
 return { $to };
 ----
 
-This will return `node`s in a breadth-first fashion.
+This will return `node` s in a breadth-first fashion.
 
 == References
 * xref:{page-version}@typeql-reference::functions/index.adoc[Functions]

--- a/core-concepts/modules/ROOT/pages/typeql/query-clauses.adoc
+++ b/core-concepts/modules/ROOT/pages/typeql/query-clauses.adoc
@@ -129,7 +129,7 @@ put # insert a friendship between them if one does not exist.
   $f isa friendship, links (friend: $p, friend: $q);
 ----
 
-==== reduce
+=== reduce
 As the name suggests, computes some value from a stream of answers,
 optionally grouped by a set of variables.
 This will return a stream with one answer per group.
@@ -144,6 +144,23 @@ match
   $p isa posting, links (page: $page, post: $post);
 reduce $views = count($post) groupby $page;
 ----
+
+Further clauses can follow a `reduce`, for instance a `match` to filter groups by their aggregated value:
+
+[,typeql]
+----
+#!test[read, count=0]
+match
+  $p isa person;
+  $f isa friendship, links (friend: $p, friend: $q);
+reduce $friends = count groupby $p;
+match
+  $friends >= 2;      # keep only people with at least two friends
+  $p has name $name;  # $p is still bound, as it was the grouping variable
+select $name, $friends;
+----
+
+Only the grouping variables (`$p`) and reducer outputs (`$friends`) are passed on; `$f` and `$q` are not available after the `reduce`.
 
 === distinct
 Removes duplicate answers in the stream.

--- a/guides/modules/ROOT/pages/typeql/advanced-pipelines.adoc
+++ b/guides/modules/ROOT/pages/typeql/advanced-pipelines.adoc
@@ -113,6 +113,50 @@ Note that when a book has multiple genres, the number of times it has been sold 
 Finished. Total answers: 8
 ----
 
+== Filter aggregated results with a `match` after a `reduce`
+
+A `reduce` can be followed by another `match`, which lets us filter groups by their aggregated value (SQL's `HAVING`) and look up further data for those that remain.
+Let's list the books that have sold at least five copies in total.
+
+[,typeql]
+----
+#!test[read, count = 3]
+match
+  $book isa book;
+  order-line ($order, $book), has quantity $quantity;
+reduce $total-sold = sum($quantity) groupby $book;
+match
+  $total-sold >= 5;
+  $book has title $title;
+sort $total-sold desc;
+fetch {
+  "title": $title,
+  "total sold": $total-sold
+};
+----
+
+The `reduce` outputs one row per `$book`, containing only `$book` and `$total-sold`.
+The second `match` filters on `$total-sold`, and uses `$book` to retrieve the title.
+
+[,json]
+----
+{
+  "title": "Under the Black Flag: The Romance and the Reality of Life Among the Pirates",
+  "total sold": 10
+}
+{
+  "title": "The Odyssey",
+  "total sold": 6
+}
+{
+  "title": "Great Discoveries in Medicine",
+  "total sold": 6
+}
+Finished. Total answers: 3
+----
+
+Note that `$order` and `$quantity` are not available after the `reduce`: only grouping variables and reduced values are.
+
 == Update user loyalty tier based on spending using `try`
 
 Imagine we want to update a user's loyalty tier based on their total spending.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@antora/cli": "3.1.5",
-    "@antora/lunr-extension": "1.0.0-alpha.8",
+    "@antora/lunr-extension": "1.0.0-alpha.13",
     "@antora/site-generator": "3.1.5",
     "@asciidoctor/tabs": "1.0.0-beta.6",
     "typedb-web-common": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: 3.1.5
         version: 3.1.5
       '@antora/lunr-extension':
-        specifier: 1.0.0-alpha.8
-        version: 1.0.0-alpha.8
+        specifier: 1.0.0-alpha.13
+        version: 1.0.0-alpha.13
       '@antora/site-generator':
         specifier: 3.1.5
         version: 3.1.5
@@ -158,8 +158,8 @@ packages:
     resolution: {integrity: sha512-DGIxiv/rsWRWxFTRD4Hu2TXiFUHOqCpiu4Rf7LxOPdKkuF6i167fw8BuZeFfTzvOE2W2FhB4sopI0EiAZ1D/vQ==}
     engines: {node: '>=16.0.0'}
 
-  '@antora/lunr-extension@1.0.0-alpha.8':
-    resolution: {integrity: sha512-vdBgW3rsvbnmA236kT2Dckh9n0Db5za2/WxiLnFLgZ05ZO1KJQa9+R2WHaIFuGE7bKKbY+lqfM/i3KiezbL9YQ==}
+  '@antora/lunr-extension@1.0.0-alpha.13':
+    resolution: {integrity: sha512-u8n8XLB6elMmXbW0bdeL5jG8UBJi6PSiz1zaMn+wIIIu/bnxotRBW4kEWSge+zTfdF4rEYMcJ9LvkAOamMyuKQ==}
     engines: {node: '>=16.0.0'}
 
   '@antora/navigation-builder@3.1.5':
@@ -281,9 +281,6 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  boolbase@1.0.0:
-    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -319,13 +316,6 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
-
-  cheerio-select@1.6.0:
-    resolution: {integrity: sha512-eq0GdBvxVFbqWgmCm7M3XGs1I8oLy/nExUnh6oLqmBditPO9AqQJrkslDpMun/hZ0yyTs8L0m85OHp4ho6Qm9g==}
-
-  cheerio@1.0.0-rc.10:
-    resolution: {integrity: sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==}
-    engines: {node: '>= 6'}
 
   clean-git-ref@2.0.1:
     resolution: {integrity: sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==}
@@ -369,13 +359,6 @@ packages:
     engines: {node: '>=0.8'}
     hasBin: true
 
-  css-select@4.3.0:
-    resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
-
-  css-what@6.2.2:
-    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
-    engines: {node: '>= 6'}
-
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -401,18 +384,18 @@ packages:
   diff3@0.0.3:
     resolution: {integrity: sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==}
 
-  dom-serializer@1.4.1:
-    resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
 
-  domhandler@4.3.1:
-    resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  domutils@2.8.0:
-    resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -427,8 +410,9 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  entities@2.2.0:
-    resolution: {integrity: sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==}
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -581,11 +565,8 @@ packages:
     resolution: {integrity: sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==}
     engines: {node: '>=14'}
 
-  html-entities@2.3.6:
-    resolution: {integrity: sha512-9o0+dcpIw2/HxkNuYKxSJUF/MMRZQECK4GnF+oQOmJ83yCVHTWgCH5aOXxK5bozNRmM8wtgryjHD3uloPBDEGw==}
-
-  htmlparser2@6.1.0:
-    resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
+  htmlparser2@9.1.0:
+    resolution: {integrity: sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -697,8 +678,8 @@ packages:
   lodash.clonedeep@4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
-  lunr-languages@1.9.0:
-    resolution: {integrity: sha512-Be5vFuc8NAheOIjviCRms3ZqFFBlzns3u9DXpPSZvALetgnydAN0poV71pVLFn0keYy/s4VblMMkqewTLe+KPg==}
+  lunr-languages@1.10.0:
+    resolution: {integrity: sha512-BBjKKcwrieJlzwwc9M5H/MRXGJ2qyOSDx/NXYiwkuKjiLOOoouh0WsDzeqcLoUWcX31y7i8sb8IgsZKObdUCkw==}
 
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
@@ -753,9 +734,6 @@ packages:
     resolution: {integrity: sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==}
     engines: {node: '>= 0.10'}
 
-  nth-check@2.1.1:
-    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
-
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
@@ -776,12 +754,6 @@ packages:
 
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
-
-  parse5-htmlparser2-tree-adapter@6.0.1:
-    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
-
-  parse5@6.0.1:
-    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
@@ -1179,12 +1151,11 @@ snapshots:
       pino-pretty: 10.0.1
       sonic-boom: 3.3.0
 
-  '@antora/lunr-extension@1.0.0-alpha.8':
+  '@antora/lunr-extension@1.0.0-alpha.13':
     dependencies:
-      cheerio: 1.0.0-rc.10
-      html-entities: 2.3.6
+      htmlparser2: 9.1.0
       lunr: 2.3.9
-      lunr-languages: 1.9.0
+      lunr-languages: 1.10.0
 
   '@antora/navigation-builder@3.1.5':
     dependencies:
@@ -1344,8 +1315,6 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  boolbase@1.0.0: {}
-
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -1389,24 +1358,6 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
-  cheerio-select@1.6.0:
-    dependencies:
-      css-select: 4.3.0
-      css-what: 6.2.2
-      domelementtype: 2.3.0
-      domhandler: 4.3.1
-      domutils: 2.8.0
-
-  cheerio@1.0.0-rc.10:
-    dependencies:
-      cheerio-select: 1.6.0
-      dom-serializer: 1.4.1
-      domhandler: 4.3.1
-      htmlparser2: 6.1.0
-      parse5: 6.0.1
-      parse5-htmlparser2-tree-adapter: 6.0.1
-      tslib: 2.8.1
-
   clean-git-ref@2.0.1: {}
 
   clone-buffer@1.0.0: {}
@@ -1438,16 +1389,6 @@ snapshots:
 
   crc-32@1.2.2: {}
 
-  css-select@4.3.0:
-    dependencies:
-      boolbase: 1.0.0
-      css-what: 6.2.2
-      domhandler: 4.3.1
-      domutils: 2.8.0
-      nth-check: 2.1.1
-
-  css-what@6.2.2: {}
-
   csstype@3.2.3: {}
 
   dateformat@4.6.3: {}
@@ -1474,23 +1415,23 @@ snapshots:
 
   diff3@0.0.3: {}
 
-  dom-serializer@1.4.1:
+  dom-serializer@2.0.0:
     dependencies:
       domelementtype: 2.3.0
-      domhandler: 4.3.1
-      entities: 2.2.0
+      domhandler: 5.0.3
+      entities: 4.5.0
 
   domelementtype@2.3.0: {}
 
-  domhandler@4.3.1:
+  domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
 
-  domutils@2.8.0:
+  domutils@3.2.2:
     dependencies:
-      dom-serializer: 1.4.1
+      dom-serializer: 2.0.0
       domelementtype: 2.3.0
-      domhandler: 4.3.1
+      domhandler: 5.0.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -1516,7 +1457,7 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  entities@2.2.0: {}
+  entities@4.5.0: {}
 
   entities@6.0.1:
     optional: true
@@ -1697,14 +1638,12 @@ snapshots:
 
   hpagent@1.2.0: {}
 
-  html-entities@2.3.6: {}
-
-  htmlparser2@6.1.0:
+  htmlparser2@9.1.0:
     dependencies:
       domelementtype: 2.3.0
-      domhandler: 4.3.1
-      domutils: 2.8.0
-      entities: 2.2.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
 
   ieee754@1.2.1: {}
 
@@ -1798,7 +1737,7 @@ snapshots:
 
   lodash.clonedeep@4.5.0: {}
 
-  lunr-languages@1.9.0: {}
+  lunr-languages@1.10.0: {}
 
   lunr@2.3.9: {}
 
@@ -1842,10 +1781,6 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  nth-check@2.1.1:
-    dependencies:
-      boolbase: 1.0.0
-
   object-keys@1.1.1: {}
 
   object.assign@4.1.7:
@@ -1868,12 +1803,6 @@ snapshots:
       readable-stream: 2.3.8
 
   pako@1.0.11: {}
-
-  parse5-htmlparser2-tree-adapter@6.0.1:
-    dependencies:
-      parse5: 6.0.1
-
-  parse5@6.0.1: {}
 
   parse5@8.0.0:
     dependencies:

--- a/typeql-reference/modules/ROOT/pages/expressions/value-operations.adoc
+++ b/typeql-reference/modules/ROOT/pages/expressions/value-operations.adoc
@@ -27,6 +27,30 @@ Parentheses (`()`) may be used to override the precedence. The sub-expressions i
 (1 + 2) * 3 == 9
 ----
 
+On strings, `+` performs concatenation (see <<_string_operations,String operations>>); the other operators are numeric only.
+
+[[_string_operations]]
+== String operations
+
+=== Concatenation
+
+The `+` operator concatenates two strings, which may be literals, values, or string-valued attributes.
+
+[,typeql]
+----
+"Hello," + " world!" == "Hello, world!"
+----
+
+For example:
+
+[,typeql]
+----
+match
+  $person isa person, has first-name $first, has last-name $last;
+  let $full-name = $first + " " + $last;
+select $full-name;
+----
+
 == Function-like operators
 
 TypeQL provides several built-in functions for common mathematical and list operations:

--- a/typeql-reference/modules/ROOT/pages/functions/writing.adoc
+++ b/typeql-reference/modules/ROOT/pages/functions/writing.adoc
@@ -164,10 +164,10 @@ with <f2-declaration>
 ...
 with <fN-declaration>
 match
-  $f1 = f1();
-  $f2 = f2();
+  let $f1 = f1();
+  let $f2 = f2();
   ...
-  $fN = fN();
+  let $fN = fN();
 ----
 
 For example, the following read pipeline defines and uses a temporary function using the `with` clause:
@@ -176,6 +176,30 @@ For example, the following read pipeline defines and uses a temporary function u
 ----
 #!test[read]
 include::{page-version}@typeql-reference::example$tql/read_statements_functions.tql[tag=with-fun]
+----
+
+Multiple query-level functions can be defined,
+with a separate `with` block per function - they can also call each other:
+
+[,typeql]
+----
+#!test[read]
+with fun karma_squared($user: user) -> double:
+  match
+    $user has karma $karma;
+    let $squared = $karma * $karma;
+  return first $squared;
+
+with fun high_karma_users($threshold: double) -> { user }:
+  match
+    $user isa user;
+    karma_squared($user) > $threshold;
+  return { $user };
+
+match
+  let $user in high_karma_users(100.0);
+  $user has username $name;
+select $name;
 ----
 
 === Using Functions in definition queries

--- a/typeql-reference/modules/ROOT/pages/pipelines/index.adoc
+++ b/typeql-reference/modules/ROOT/pages/pipelines/index.adoc
@@ -1,9 +1,6 @@
 = Data pipelines
 :page-aliases: {page-version}@typeql::pipelines.adoc
 
-// TODO: this page should say something about how stages combine
-// and give examples of how inputs and outputs are passed
-
 This reference covers the usage of data pipelines in TypeQL. Data pipeline read and modify data in stages.
 
 [[pipeline_kinds]]
@@ -11,6 +8,27 @@ This reference covers the usage of data pipelines in TypeQL. Data pipeline read 
 
 * A *write pipeline* may comprise stages that modify data in the database (such as `insert` or `delete`).
 * A *read pipeline* only comprises stages that read data from the database but do not modify it.
+
+[[combining_stages]]
+== Combining stages
+
+Each stage receives the stream of rows output by the previous stage, and only the variables in those rows are available to it.
+Stages may be chained in any order permitted by their kind, and a stage kind may appear more than once -- for instance, a `match` may follow a `reduce`:
+
+[,typeql]
+----
+match
+  $user isa user;
+  friendship($user, $friend);
+reduce $friend-count = count groupby $user;
+match
+  $friend-count >= 2;
+  $user has username $username;
+select $username, $friend-count;
+----
+
+Here the second `match` sees only `$user` and `$friend-count`, the output of the `reduce`.
+See xref:{page-version}@typeql-reference::pipelines/reduce.adoc#_using_reduced_values_in_later_stages[Using reduced values in later stages].
 
 == Data manipulation stages
 

--- a/typeql-reference/modules/ROOT/pages/pipelines/match.adoc
+++ b/typeql-reference/modules/ROOT/pages/pipelines/match.adoc
@@ -56,7 +56,7 @@ include::{page-version}@typeql-reference::example$tql/schema_statements_function
 ----
 ====
 
-1. Retrieve usernames of user who have more than 400 friends:
+1. Retrieve usernames of users who have more than 500 friends:
 +
 [,typeql]
 ----

--- a/typeql-reference/modules/ROOT/pages/pipelines/reduce.adoc
+++ b/typeql-reference/modules/ROOT/pages/pipelines/reduce.adoc
@@ -38,7 +38,7 @@ include::{page-version}@typeql-reference::example$tql/schema_statements_function
   entity file, owns size-kb;
 
   relation located, relates country, relates user;
-  entity country, plays located:country;
+  entity country, owns name, plays located:country;
   user plays located:user;
 ----
 ====
@@ -93,4 +93,40 @@ match
     located($place, $country);
   };
 reduce $user-count = count groupby $country;
+----
+
+== Using reduced values in later stages
+
+A `reduce` need not be the last stage.
+Its output rows contain only the reduced variables and the grouping variables, and later stages -- including another `match` -- can use them.
+All other variables are dropped.
+
+Filter groups by a reduced value (SQL's `HAVING`), then retrieve more data using the grouping variable:
+
+[,typeql]
+----
+#!test[read]
+match
+  $user isa user;
+  friendship($user, $friend);
+reduce $friend-count = count groupby $user;
+match
+  $friend-count >= 2;
+  $user has username $username;
+select $username, $friend-count;
+----
+
+Retrieve more data for each group without filtering:
+
+[,typeql]
+----
+#!test[read]
+match
+  $user isa user;
+  located($user, $country);
+reduce $user-count = count groupby $country;
+match
+  $country has name $country-name;
+sort $user-count desc;
+select $country-name, $user-count;
 ----

--- a/typeql-reference/modules/ROOT/pages/pipelines/with.adoc
+++ b/typeql-reference/modules/ROOT/pages/pipelines/with.adoc
@@ -2,7 +2,7 @@
 :test-typeql: linear
 
 The preamble of a pipeline allows the local declaration of functions using `with` statements.
-These functions can be called from the pipeline, and from other premable functions.
+These functions can be called from the pipeline, and from other preamble functions.
 
 == Syntax
 
@@ -75,5 +75,8 @@ match
   $y has username $pop_name;
 select $pop_name;
 ----
++
+Note that when declaring multiple preamble functions,
+each requires its own `with` statement.
 
 

--- a/typeql-reference/modules/ROOT/pages/values/string.adoc
+++ b/typeql-reference/modules/ROOT/pages/values/string.adoc
@@ -12,6 +12,25 @@ Strings can be concatenated using the `+` operator.
 "Hello," + " world!" == "Hello, world!" 
 ----
 
+Literals, string values, and string attributes can be combined:
+
+[,typeql]
+----
+#!test[schema]
+#{{
+define entity person owns name;
+#}}
+#!test[write]
+#{{
+insert $p isa person, has name "John";
+#}}
+#!test[read, count=1]
+match
+  $name isa name;
+  let $greeting = "Hello, " + $name + "!";
+select $greeting;
+----
+
 == Defining a string valued attribute
 
 [,typeql]
@@ -41,6 +60,3 @@ match
   let $y = "ABC 𓃭𓅓";
   $x == $y;
 ----
-
-
-

--- a/typeql-reference/modules/ROOT/pages/values/string.adoc
+++ b/typeql-reference/modules/ROOT/pages/values/string.adoc
@@ -18,7 +18,9 @@ Literals, string values, and string attributes can be combined:
 ----
 #!test[schema]
 #{{
-define entity person owns name;
+define
+attribute name, value string;
+entity person, owns name;
 #}}
 #!test[write]
 #{{


### PR DESCRIPTION
## Goal

- Add new and clarify existing examples on:
  - String concatenation
  - Pipeline chaining (`reduce` -> `match`)
  - Multiple preamble functions
- Improve searchability of the "Queries as Functions" page
 
## Implementation

- Add/clarify the new examples
- Bump the antora lunr extension to a version that indexes keywords
- Add keywords to the "Queries as Functions" page