### PR TITLE
Document HTTP analyze endpoint

### DIFF
--- a/core-concepts/modules/ROOT/pages/drivers/best-practices.adoc
+++ b/core-concepts/modules/ROOT/pages/drivers/best-practices.adoc
@@ -258,6 +258,11 @@ For data loading workloads, we recommend batching approximately 100-1000 queries
 
 If you know that all your queries are valid, the `resolve()` call can be omitted for even higher performance.
 
+When the queries in a batch are the same pattern instantiated with different values, prefer a single query with a
+xref:{page-version}@typeql-reference::pipelines/given.adoc[given] stage, passing one input row per value set.
+The query is parsed and planned once and executed for all rows, which is typically an order of magnitude faster than
+submitting one insert query per row — as well as more robust than generating query strings.
+
 === Security considerations
 
 * **Never hardcode credentials**: Use environment variables or secure configuration management

--- a/core-concepts/modules/ROOT/pages/typedb/transactions.adoc
+++ b/core-concepts/modules/ROOT/pages/typedb/transactions.adoc
@@ -51,3 +51,7 @@ Schema transactions can execute read queries, data update queries, and schema mu
 
 * Schema transactions can *mutate both data and schema* at the same time, allowing atomic migrations from one database state to another.
 
+Because of their exclusivity, always use the weakest transaction type that fits your operation, and keep schema transactions short-lived: while one is open, no write transactions can be opened.
+Note that rolling back a schema transaction does not release its exclusive lock — only closing or committing it does.
+A transaction open that is blocked by an exclusive transaction waits up to the `schema_lock_acquire_timeout_millis` transaction option (10 seconds by default) before failing with a timeout error.
+

--- a/reference/modules/ROOT/pages/typedb-http-api.adoc
+++ b/reference/modules/ROOT/pages/typedb-http-api.adoc
@@ -930,6 +930,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 Open a new transaction and receive a unique transaction id.
 
+TIP: Use the weakest transaction type that fits your operation (`read` < `write` < `schema`): schema transactions are exclusive and block all other write and schema transactions from opening while they are open.
+
 [cols="h,3a"]
 |===
 | Token required           | Yes

--- a/reference/modules/ROOT/pages/typedb-http-api.adoc
+++ b/reference/modules/ROOT/pages/typedb-http-api.adoc
@@ -1393,8 +1393,6 @@ See xref:{page-version}@core-concepts::drivers/analyze.adoc[Analyzing queries] f
 
 Only query pipelines can be analyzed: passing a schema query (`define`, `undefine`, or `redefine`) returns a `400` error.
 
-NOTE: The shape of the response body of this endpoint is still evolving and is exempt from the versioning guarantees of the rest of this API: it may change between server minor versions.
-
 [cols="h,3a"]
 |===
 | Token required           | Yes

--- a/reference/modules/ROOT/pages/typedb-http-api.adoc
+++ b/reference/modules/ROOT/pages/typedb-http-api.adoc
@@ -1042,6 +1042,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 === Close transaction
 
 Close a transaction without preserving its changes by transaction id.
+This operation is idempotent: closing a transaction that is already closed (or was never opened) succeeds with an empty `200` response.
 
 [cols="h,3a"]
 |===
@@ -1170,6 +1171,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 === Rollback transaction
 
 Rolls back the uncommitted changes made via a transaction.
+The transaction remains open afterwards and can accept further queries.
+To dispose of a transaction without committing, use <<_close_transaction,close>> instead.
 
 [cols="h,3a"]
 |===
@@ -1266,11 +1269,19 @@ If there are more answers cut, a relevant `warning` will be provided in the resp
 **Default:**
 include::{page-version}@reference::partial$options-descriptions/query.adoc[tag=answer-count-limit-default]
 
+
+| `includeQueryStructure` |
+include::{page-version}@reference::partial$options-descriptions/query.adoc[tag=include-query-structure]
+
+**Default:**
+include::{page-version}@reference::partial$options-descriptions/query.adoc[tag=include-query-structure-default]
+
 |===
 // end::query-options[]
 *Given rows:*
 
 Each given row maps a 'given' variable to an instance or value.
+For write queries, passing many given rows to a single query is the most efficient way to bulk-load data: the query is parsed and planned once and executed for all rows.
 .Examples:
 [%collapsible]
 ====
@@ -1372,6 +1383,99 @@ include::{page-version}@reference::partial$http-api/requests/transactions-query-
 =====
 
 include::{page-version}@reference::partial$http-api/responses/query-concept-documents-example.json.adoc[]
+====
+
+=== Analyze query in transaction
+
+Analyzes a query within an open transaction, without executing it.
+The query is parsed and type-checked against the schema, and the response is a type-annotated structural representation of the query.
+See xref:{page-version}@core-concepts::drivers/analyze.adoc[Analyzing queries] for an overview of the concepts involved and the envisioned uses.
+
+Only query pipelines can be analyzed: passing a schema query (`define`, `undefine`, or `redefine`) returns a `400` error.
+
+NOTE: The shape of the response body of this endpoint is still evolving and is exempt from the versioning guarantees of the rest of this API: it may change between server minor versions.
+
+[cols="h,3a"]
+|===
+| Token required           | Yes
+| Method                   | `POST`
+| URL                      | `/v1/transactions/TRANSACTION_ID/analyze`
+| Request body             | include::{page-version}@reference::partial$http-api/requests/transactions-analyze.json.adoc[]
+| Request headers          | `Authorization: Bearer ACCESS_TOKEN`
+|===
+
+*Responses:*
+
+include::{page-version}@reference::partial$http-api/responses/details.adoc[tags="200-analyze,400,403,404,408"]
+
+*Example request:*
+
+[tabs]
+====
+curl::
++
+[source,console]
+----
+
+curl --request POST \
+  --url http://localhost:8000/v1/transactions/TRANSACTION_ID/analyze \
+  --header 'Authorization: Bearer {ACCESS-TOKEN}' \
+  --json '{"query": "match $person isa person, has name $name;"}'
+----
+
+Python::
++
+[source,python]
+----
+import requests
+
+url = "http://localhost:8000/v1/transactions/TRANSACTION_ID/analyze"
+
+headers = {
+    "Authorization": "Bearer {ACCESS-TOKEN}"
+}
+body = {
+    "query": "match $person isa person, has name $name;"
+}
+
+response = requests.post(url, headers=headers, json=body)
+----
+
+Rust::
++
+[source,rust]
+----
+use reqwest;
+use serde::Serialize;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Analyze {
+    query: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let analyze = Analyze {
+        query: "match $person isa person, has name $name;".to_string(),
+    };
+    let client = reqwest::Client::new();
+    let resp = client
+        .post("http://localhost:8000/v1/transactions/TRANSACTION_ID/analyze")
+        .header(reqwest::header::AUTHORIZATION, "Bearer {ACCESS-TOKEN}")
+        .json(&analyze)
+        .send().await;
+    Ok(())
+}
+----
+====
+
+*Example response:*
+
+.Analyzed query
+[%collapsible]
+====
+include::{page-version}@reference::partial$http-api/responses/transactions-analyze-example.json.adoc[]
 ====
 
 == One-shot query

--- a/reference/modules/ROOT/partials/http-api/requests/transactions-analyze.json.adoc
+++ b/reference/modules/ROOT/partials/http-api/requests/transactions-analyze.json.adoc
@@ -1,0 +1,6 @@
+[source,json]
+----
+{
+    "query": string
+}
+----

--- a/reference/modules/ROOT/partials/http-api/requests/transactions-query.json.adoc
+++ b/reference/modules/ROOT/partials/http-api/requests/transactions-query.json.adoc
@@ -2,9 +2,10 @@
 ----
 {
     "query": string,
-    "queryOptions": {                    // optional
-        "includeInstanceTypes": boolean, // optional
-        "answerCountLimit": integer      // optional
+    "queryOptions": {                       // optional
+        "includeInstanceTypes": boolean,    // optional
+        "answerCountLimit": integer,        // optional
+        "includeQueryStructure": boolean    // optional
     },
     "given": GivenRow[],
 }

--- a/reference/modules/ROOT/partials/http-api/responses/analyze.json.adoc
+++ b/reference/modules/ROOT/partials/http-api/responses/analyze.json.adoc
@@ -1,0 +1,10 @@
+[source,json]
+----
+{
+  "source": string,       // the analyzed query text
+  "query": Pipeline,      // the analyzed query pipeline: conjunctions, stages, variables, outputs
+  "preamble": Function[], // analyzed preamble functions ('with fun ...')
+  "given": Given,         // optional: input variables and their annotations, if the query has a 'given' stage
+  "fetch": Fetch          // optional: possible fields of the fetch result, if the query has a 'fetch' stage
+}
+----

--- a/reference/modules/ROOT/partials/http-api/responses/details.adoc
+++ b/reference/modules/ROOT/partials/http-api/responses/details.adoc
@@ -70,6 +70,14 @@ include::{page-version}@reference::partial$http-api/responses/query.json.adoc[]
 ====
 // end::200-query[]
 
+// tag::200-analyze[]
+.200: OK
+[%collapsible]
+====
+include::{page-version}@reference::partial$http-api/responses/analyze.json.adoc[]
+====
+// end::200-analyze[]
+
 // tag::204-empty[]
 .204: No Content
 [%collapsible]

--- a/reference/modules/ROOT/partials/http-api/responses/query.json.adoc
+++ b/reference/modules/ROOT/partials/http-api/responses/query.json.adoc
@@ -4,6 +4,7 @@
   "queryType": "read" | "write" | "schema",
   "answerType": "ok" | "conceptRows" | "conceptDocuments",
   "answers": [ ... ], // optional
+  "query": { ... },   // optional: structural analysis of the query, controlled by the includeQueryStructure query option
   "warning": string   // optional
 }
 ----

--- a/reference/modules/ROOT/partials/http-api/responses/transactions-analyze-example.json.adoc
+++ b/reference/modules/ROOT/partials/http-api/responses/transactions-analyze-example.json.adoc
@@ -1,0 +1,112 @@
+[source,json]
+----
+{
+    "source": "match $person isa person, has name $name;",
+    "given": null,
+    "query": {
+        "conjunctions": [
+            {
+                "constraints": [
+                    {
+                        "textSpan": {
+                            "begin": 14,
+                            "end": 24
+                        },
+                        "tag": "isa",
+                        "instance": {
+                            "tag": "variable",
+                            "id": "0"
+                        },
+                        "type": {
+                            "tag": "label",
+                            "type": {
+                                "kind": "entityType",
+                                "label": "person"
+                            }
+                        }
+                    },
+                    {
+                        "textSpan": {
+                            "begin": 26,
+                            "end": 40
+                        },
+                        "tag": "has",
+                        "owner": {
+                            "tag": "variable",
+                            "id": "0"
+                        },
+                        "attribute": {
+                            "tag": "variable",
+                            "id": "1"
+                        }
+                    },
+                    {
+                        "textSpan": {
+                            "begin": 30,
+                            "end": 34
+                        },
+                        "tag": "isa",
+                        "instance": {
+                            "tag": "variable",
+                            "id": "1"
+                        },
+                        "type": {
+                            "tag": "label",
+                            "type": {
+                                "kind": "attributeType",
+                                "label": "name",
+                                "valueType": "string"
+                            }
+                        }
+                    }
+                ],
+                "annotations": {
+                    "variableAnnotations": {
+                        "1": {
+                            "isOptional": false,
+                            "tag": "instance",
+                            "annotations": [
+                                {
+                                    "kind": "attributeType",
+                                    "label": "name",
+                                    "valueType": "string"
+                                }
+                            ]
+                        },
+                        "0": {
+                            "isOptional": false,
+                            "tag": "instance",
+                            "annotations": [
+                                {
+                                    "kind": "entityType",
+                                    "label": "person"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        ],
+        "stages": [
+            {
+                "tag": "match",
+                "block": 0
+            }
+        ],
+        "variables": {
+            "1": {
+                "name": "name"
+            },
+            "0": {
+                "name": "person"
+            }
+        },
+        "outputs": [
+            "0",
+            "1"
+        ]
+    },
+    "preamble": [],
+    "fetch": null
+}
+----

--- a/reference/modules/ROOT/partials/options-descriptions/query.adoc
+++ b/reference/modules/ROOT/partials/options-descriptions/query.adoc
@@ -21,6 +21,19 @@ If it is a write query, all changes, including both returned and not returned, w
 10 000
 // end::answer-count-limit-default[]
 
+== Include query structure
+// tag::include-query-structure[]
+Whether to include a structural analysis of the query in the `query` field of concept row responses.
+This is used, for example, by TypeDB Studio to visualize answers.
+
+The analysis adds a constant overhead (typically under 1 KB) to every response, independent of the number of answers returned.
+Set this option to `false` to minimize response sizes.
+// end::include-query-structure[]
+
+// tag::include-query-structure-default[]
+true
+// end::include-query-structure-default[]
+
 == Prefetch size
 // tag::prefetch-size[]
 The number of extra query responses sent before the client side has to re-request more responses.

--- a/typeql-reference/modules/ROOT/pages/pipelines/insert.adoc
+++ b/typeql-reference/modules/ROOT/pages/pipelines/insert.adoc
@@ -34,6 +34,9 @@ The output stream in that case contains a single row containing the newly insert
 If the insert stage is preceded by other stages, its body is executed once for each input row.
 The output is then a stream of input rows extended with the newly inserted values.
 
+TIP: To insert the same pattern many times with different values — for example, when bulk-loading — precede the insert stage with a xref:{page-version}@typeql-reference::pipelines/given.adoc[given] stage and pass one input row per value set.
+This executes a single query for all rows, which is far faster than submitting a separate insert query per row.
+
 [#_validation]
 == Validation
 Attempting to insert the following fail immediately and terminate the transaction:

--- a/typeql-reference/modules/ROOT/pages/pipelines/insert.adoc
+++ b/typeql-reference/modules/ROOT/pages/pipelines/insert.adoc
@@ -34,7 +34,7 @@ The output stream in that case contains a single row containing the newly insert
 If the insert stage is preceded by other stages, its body is executed once for each input row.
 The output is then a stream of input rows extended with the newly inserted values.
 
-TIP: To insert the same pattern many times with different values — for example, when bulk-loading — precede the insert stage with a xref:{page-version}@typeql-reference::pipelines/given.adoc[given] stage and pass one input row per value set.
+TIP: To insert the same pattern many times with different values — for example, when bulk-loading — start the pipeline with a xref:{page-version}@typeql-reference::pipelines/given.adoc[given] stage and pass one input row per value set.
 This executes a single query for all rows, which is far faster than submitting a separate insert query per row.
 
 [#_validation]


### PR DESCRIPTION


## Goal
Document HTTP analyze endpoint, includeQueryStructure option, and transaction lifecycle clarifications

- Add the previously undocumented POST /v1/transactions/{id}/analyze endpoint to the HTTP API reference, with request/response schemas and examples
- Document the includeQueryStructure query option (defaults to true; constant per-response size cost) and the query field of query responses
- Clarify that rollback leaves the transaction open, and that close is idempotent
- Recommend 'given' rows for bulk loading in the insert reference, driver best practices, and the HTTP API given-rows section

## Implementation
